### PR TITLE
fix: trace-commit.yml — push to traces branch with error handling and fallback

### DIFF
--- a/.github/workflows/trace-commit.yml
+++ b/.github/workflows/trace-commit.yml
@@ -103,11 +103,54 @@ jobs:
           run-id: ${{ steps.find.outputs.run_id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Commit trace to master
-        if: steps.precheck.outputs.skip != 'true' && steps.find.outputs.found == 'true'
+      - name: Generate fallback trace if artifact missing
+        if: steps.precheck.outputs.skip != 'true' && steps.find.outputs.found != 'true'
         run: |
+          # Fallback: create a minimal trace record from merge commit context
+          mkdir -p workspace/traces/
+          timestamp=$(date -u +'%Y-%m-%dT%H-%M-%S-%3NZ')
+          trace_file="workspace/traces/${timestamp}-ci-$(git rev-parse HEAD | cut -c1-8).jsonl"
+          echo "{\"eventType\": \"trace-commit-fallback\", \"reason\": \"assurance-trace artifact not found\", \"commitSha\": \"${{ github.sha }}\", \"timestamp\": \"${timestamp}\", \"gate_run_id\": \"${{ steps.find.outputs.run_id }}\", \"fallback\": true}" > "$trace_file"
+          echo "Generated fallback trace: $trace_file"
+          cat "$trace_file"
+
+      - name: Commit trace to traces branch
+        if: steps.precheck.outputs.skip != 'true'
+        run: |
+          set +e  # Don't exit on first error; we want to see all issues
+          
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+          
+          # Check if traces branch exists; if not, create it
+          if ! git rev-parse --verify origin/traces >/dev/null 2>&1; then
+            echo "traces branch does not exist; creating from master"
+            git checkout -b traces
+          else
+            git checkout traces
+            git pull origin traces --ff-only || git pull origin traces
+          fi
+          
+          # Add trace files and commit
           git add -f workspace/traces/
-          git diff --staged --quiet || git commit -m "chore: assurance trace [post-merge] ${{ github.sha }}"
-          git push origin master
+          if git diff --staged --quiet; then
+            echo "No trace files to commit."
+            exit 0
+          fi
+          
+          commit_msg="chore: assurance trace [post-merge] ${{ github.sha }}"
+          if ! git commit -m "$commit_msg"; then
+            echo "Commit failed; exiting without push"
+            exit 1
+          fi
+          
+          # Push to traces branch (should not have the same branch protection as master)
+          if ! git push origin traces; then
+            echo "ERROR: push to traces branch failed"
+            echo "Troubleshooting: checking branch rules..."
+            git remote -v
+            git branch -vv
+            exit 1
+          fi
+          
+          echo "Trace committed successfully to traces branch"

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -204,9 +204,11 @@ Domain-tier extensions (squad-specific overrides) are declared in the squad's `c
 | Estimation actuals | `workspace/phase2-actuals.md` |
 | State and checkpoint | `workspace/state.json` |
 | Eval regression suite | `workspace/suite.json` |
-| Delivery traces | `workspace/traces/` |
+| Delivery traces | `workspace/traces/` (files); `origin/traces` branch (permanent store) |
 | Improvement proposals | `workspace/proposals/` |
 | Adoption readiness (RAG) | `workspace/adoption-readiness.md` |
+
+**`traces` branch — ruleset note:** The `traces` branch is a permanent append-only branch that holds all CI assurance trace JSONL files. It is written exclusively by the `trace-commit.yml` GitHub Actions workflow (github-actions bot push) after each inner loop PR merge. No human direct-push is permitted; no PR is required to write to this branch. The branch ruleset should allow pushes only from the `trace-commit.yml` workflow identity. **Fleet fork operators:** recreate the `traces` branch and matching branch ruleset on your fork before running any inner loop story. Without the branch and ruleset in place, the `trace-commit.yml` post-merge step will fail silently and traces will be lost.
 
 ---
 
@@ -215,6 +217,23 @@ Domain-tier extensions (squad-specific overrides) are declared in the squad's `c
 ### 6.1 Entry condition met
 
 T3M1 (Tier 3, Meta-metric 1 — independent non-engineer audit) is on record in `MODEL-RISK.md` with Hamish sign-off 2026-04-12, outcome "approved with conditions", 3/8 Y baseline. Phase 3 /discovery is unblocked. The five T3M1 gap closures (Q2, Q5, Q6, Q7, Q8 — see Section 3.1) become Phase 3 story candidates.
+
+**Raw artefact links for reconstruction** (use these if working from a fork, partial clone, or outside this repo):
+
+| Artefact | Raw URL |
+|----------|---------|
+| MODEL-RISK.md (T3M1 evidence + sign-off) | https://raw.githubusercontent.com/heymishy/skills-repo/refs/heads/master/MODEL-RISK.md |
+| Phase 1 discovery | https://raw.githubusercontent.com/heymishy/skills-repo/refs/heads/master/artefacts/2026-04-09-skills-platform-phase1/discovery.md |
+| Phase 1 benefit-metric | https://raw.githubusercontent.com/heymishy/skills-repo/refs/heads/master/artefacts/2026-04-09-skills-platform-phase1/benefit-metric.md |
+| Phase 1 decisions | https://raw.githubusercontent.com/heymishy/skills-repo/refs/heads/master/artefacts/2026-04-09-skills-platform-phase1/decisions.md |
+| Phase 1 p1.8 DoR (model risk story) | https://raw.githubusercontent.com/heymishy/skills-repo/refs/heads/master/artefacts/2026-04-09-skills-platform-phase1/dor/p1.8-model-risk-documentation-dor.md |
+| Phase 1 p1.8 DoR contract | https://raw.githubusercontent.com/heymishy/skills-repo/refs/heads/master/artefacts/2026-04-09-skills-platform-phase1/dor/p1.8-model-risk-documentation-dor-contract.md |
+| Phase 2 discovery | https://raw.githubusercontent.com/heymishy/skills-repo/refs/heads/master/artefacts/2026-04-11-skills-platform-phase2/discovery.md |
+| Phase 2 benefit-metric | https://raw.githubusercontent.com/heymishy/skills-repo/refs/heads/master/artefacts/2026-04-11-skills-platform-phase2/benefit-metric.md |
+| Phase 2 decisions | https://raw.githubusercontent.com/heymishy/skills-repo/refs/heads/master/artefacts/2026-04-11-skills-platform-phase2/decisions.md |
+| Phase 2 p2.4 DoR (T3M1 evaluation trace story) | https://raw.githubusercontent.com/heymishy/skills-repo/refs/heads/master/artefacts/2026-04-11-skills-platform-phase2/dor/p2.4-agents-md-adapter-dor.md |
+| Phase 2 p2.11 DoR (improvement agent) | https://raw.githubusercontent.com/heymishy/skills-repo/refs/heads/master/artefacts/2026-04-11-skills-platform-phase2/dor/p2.11-improvement-agent-trace-proposals-dor.md |
+| T3M1 evaluation trace (p2.4 / PR #31) | https://raw.githubusercontent.com/heymishy/skills-repo/refs/heads/traces/workspace/traces/2026-04-11T21-33-02-002Z-ci-84f82370.jsonl |
 
 ### 6.2 /levelup renamed to /improve
 

--- a/tests/smoke-tests.md
+++ b/tests/smoke-tests.md
@@ -44,7 +44,7 @@ Run a smoke test when you:
 | /definition-of-done | ✅ | — (requires merged PR) |
 | /trace | ✅ | T10 |
 | /release | ✅ | — (requires DoD artefacts) |
-| /levelup | ✅ | — (requires merged PR) |
+| /improve | ✅ | — (requires merged PR) |
 | /systematic-debugging | ✅ | — (requires failing test) |
 | /implementation-review | ✅ | — (requires code) |
 | /spike | ✅ | — (requires specific question) |

--- a/workspace/adoption-readiness.md
+++ b/workspace/adoption-readiness.md
@@ -27,7 +27,7 @@
 
 **Green (achieved and evidenced):** M2, M3, M4, MM1, MM3, MM5 — core platform capabilities and delivery pipeline are operational and proven in dogfood.
 
-**Amber (built but unproven at customer scale):** M1, MM2, MM4 — the toolchain exists; the evidence events require a real Westpac operator run (M1) or a 30-minute Phase 2 /levelup action (MM2, MM4). None of the amber items require new code.
+**Amber (built but unproven at customer scale):** M1, MM2, MM4 — the toolchain exists; the evidence events require a real Westpac operator run (M1) or a 30-minute Phase 2 /improve run (MM2, MM4). None of the amber items require new code.
 
 **Red (not yet achieved):** M5 — non-engineer approval requires a live, configured Jira/Confluence/Slack environment and a real approver. This is the one item that requires scoping effort before a Westpac pilot can claim this outcome.
 

--- a/workspace/phase2-actuals.md
+++ b/workspace/phase2-actuals.md
@@ -2,7 +2,7 @@
 
 **Prepared:** 2026-04-12
 **Source data:** `workspace/estimation-norms.md`, `workspace/results.tsv`, `workspace/state.json`
-**E3 run date:** 2026-04-12 (Phase 2 /levelup)
+**E3 run date:** 2026-04-12 (Phase 2 /improve)
 
 ---
 


### PR DESCRIPTION
## Problem

The \	race-commit.yml\ workflow was failing silently after PR merges:
- Attempted to push directly to \master\ branch
- Master branch protection now requires PR + assurance gate
- github-actions[bot] push was rejected
- Traces were lost; no audit record on either branch

## Solution  

- **Target branch change:** Push traces to \	races\ branch (per HANDOFF.md design) instead of \master\
- **Error handling:** Wrap commit+push in error handling with diagnostics
- **Fallback trace:** Generate minimal trace record from merge commit context if assurance-trace artifact is missing
- **Branch creation:** Handle case where traces branch doesn't exist yet

## Changes in trace-commit.yml

1. Added \Generate fallback trace if artifact missing\ step
2. Renamed \Commit trace to master\ → \Commit trace to traces branch\
3. Changed push target from \master\ to \	races\
4. Added error handling and diagnostics
5. Added traces branch creation logic

## Testing

- [ ] Merge this PR
- [ ] Watch trace-commit workflow run on post-merge push event
- [ ] Verify trace file appears on \origin/traces\ branch (not master)
- [ ] Verify rollback: missing artifact generates fallback trace with metadata