### PR TITLE
fix: trace-commit.yml — fetch refs first, force-with-lease push

### DIFF
--- a/.github/workflows/trace-commit.yml
+++ b/.github/workflows/trace-commit.yml
@@ -122,10 +122,13 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           
+          # CRITICAL FIX: Fetch all refs from origin FIRST, before any ref checks
+          # This ensures origin/traces detection is accurate, not based on stale local refs
+          git fetch origin
+          
           # Checkout traces branch, creating a tracking branch if needed
           if git rev-parse --verify origin/traces >/dev/null 2>&1; then
             echo "Checking out existing remote traces branch"
-            git fetch origin traces
             git checkout -b traces origin/traces 2>/dev/null || git checkout traces
           else
             echo "Creating new traces branch from current HEAD"
@@ -145,8 +148,8 @@ jobs:
             exit 1
           fi
           
-          # Push to traces branch (should not have the same branch protection as master)
-          if ! git push origin traces; then
+          # Push to traces branch with force-with-lease for safe append-only semantics
+          if ! git push -u origin traces --force-with-lease; then
             echo "ERROR: push to traces branch failed"
             echo "Troubleshooting: checking branch state..."
             git remote -v


### PR DESCRIPTION
## Root Cause

Previous fix checked for \origin/traces\ before fetching — stale local refs check

## Solution

- \git fetch origin\ at start to sync all remote refs FIRST
- Check \origin/traces\ after fetch (now accurate)
- Use \--force-with-lease\ on push to safely override divergent history
- Safe because traces branch is append-only; no data loss

## Result

After PR #54 merge:
- PR #54 created trace on traces branch → remote now has traces
- PR #55 tests with traces already on remote
- This time, fetch will see it and checkout correctly