### PR TITLE
fix: restore workspace state schema for clean clone validation

### DIFF
--- a/workspace/state.json
+++ b/workspace/state.json
@@ -29,6 +29,13 @@
                       },
     "lastUpdated":  "2026-04-13T12:34:52Z",
     "currentPhase":  "post-phase-2-checkpoint",
+    "cycle":  {
+                  "discovery":  {
+                                    "status":  "completed",
+                                    "artefact":  "artefacts/2026-04-11-skills-platform-phase2/discovery.md",
+                                    "completedAt":  null
+                                }
+              },
     "checkpoint":  {
                        "resumeInstruction":  "New session: run \u0027/workflow\u0027 to begin Phase 3. Backlog story \u0027phase3-backlog-trace-commit-observability\u0027 is registered in workspace/ and ready for /discovery intake immediately.",
                        "contextAtWrite":  "Phase 2 complete: 6/7 stories signed-off (p2.6 blocked). Post-merge workflow trace-commit.yml fixed (PR #55). Four observability gaps logged to learnings.md. Phase 3 backlog story created: phase3-backlog-trace-commit-observability.md. Ready for phase 3 discovery.",


### PR DESCRIPTION
## Summary
Restore the required workspace state schema fields in workspace/state.json so a fresh clone passes the workspace-state governance check during validation-playbook Step 2.

## Problem
A clean clone of master failed 
pm test in 	ests/check-workspace-state.js because workspace/state.json did not include the required cycle.discovery block.

## Change
- add cycle.discovery.status
- add cycle.discovery.artefact
- add cycle.discovery.completedAt

## Validation
- 
ode tests/check-workspace-state.js
- 
pm test

## Notes
This PR intentionally excludes unrelated local deletions in FINAL-TEST.md and TEST-TRACE.md.