### PR TITLE
fix: validate-trace check_test_plan_coverage - handle Phase 3 story structure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ All notable changes to this repository will be documented in this file.
 
 ### Fixed
 
+- **`scripts/validate-trace.sh` — `check_test_plan_coverage` three-bug fix (2026-04-15):** (1) Phase 3 stores string slugs (e.g. `"p3.1a"`) in `epic.stories[]`, not story objects — calling `.get()` on a string raised `AttributeError`, crashing the check on every PR touching `.github/skills/**`. (2) Phase 3 story slugs are short (`p3.1a`) while filenames use the full name (`p3.1a-trace-commit-observability-test-plan.md`) — path construction was wrong even if (1) were fixed. (3) The `python3 ...; if [[ $? -eq 0 ]]` pattern is unsafe under `set -euo pipefail` — a non-zero Python exit kills the script before the `if` runs. Fix: collect story objects from `feature.stories[]` first (Phase 3+ style), falling back to epic-nested objects (Phase 1/2 style); derive the file slug from the story's `artefact` path basename; convert to `if python3 ...; then` syntax.
+
 - `.github/workflows/assurance-gate.yml` — `permissions.contents` upgraded from `read` to `write`; "Commit trace file" step added after gate run (ran with `if: always()`) to `git add workspace/traces/`, commit with `[ci skip]` message, and push back to the PR branch ref via `HEAD:${{ github.head_ref }}`. Fixed gap where trace JSONL files were written to runner filesystem during gate execution but discarded on runner exit. This was a necessary intermediate step (required for p1.8 AC3 evaluation and p2.11/p2.12 DoR gate clearance) that has since been superseded by the post-merge architecture described in Changed above (2026-04-12; superseded 2026-04-13)
 
 ### Added

--- a/scripts/validate-trace.sh
+++ b/scripts/validate-trace.sh
@@ -163,8 +163,7 @@ check_test_plan_coverage() {
         ok "No pipeline-state.json — skipping"
         return
     fi
-    local missing=0
-    python3 - <<PYTHON
+    if python3 - <<PYTHON
 import json, os, sys
 
 with open('$STATE_FILE') as f:
@@ -174,18 +173,33 @@ stages_needing_test_plan = {'test-plan','definition-of-ready','implementation','
 missing = []
 for feature in state.get('features', []):
     feature_slug = feature.get('slug', 'unknown')
-    for epic in feature.get('epics', []):
-        for story in epic.get('stories', []):
-            story_slug = story.get('slug', 'unknown')
-            stage = story.get('stage', '')
-            if stage in stages_needing_test_plan:
-                test_plan_path = os.path.join('artefacts', feature_slug, 'test-plans', f'{story_slug}-test-plan.md')
-                if not os.path.exists(test_plan_path):
-                    print(f'MISSING: {test_plan_path}')
-                    missing.append(test_plan_path)
+
+    # Collect all story objects. Phase 3+ stores full objects in feature.stories[];
+    # Phase 1/2 stores full objects nested inside epic.stories[].
+    # Epic.stories[] may also contain plain string slugs (Phase 3) — skip those.
+    stories = [s for s in feature.get('stories', []) if isinstance(s, dict)]
+    if not stories:
+        for epic in feature.get('epics', []):
+            stories += [s for s in epic.get('stories', []) if isinstance(s, dict)]
+
+    for story in stories:
+        stage = story.get('stage', '')
+        if stage not in stages_needing_test_plan:
+            continue
+        # Derive the file slug from the artefact path basename so that both
+        # short slugs (e.g. "p3.1a") and full slugs resolve to the correct filename.
+        artefact = story.get('artefact', '')
+        if artefact:
+            file_slug = os.path.basename(artefact).replace('.md', '')
+        else:
+            file_slug = story.get('slug', 'unknown')
+        test_plan_path = os.path.join('artefacts', feature_slug, 'test-plans', f'{file_slug}-test-plan.md')
+        if not os.path.exists(test_plan_path):
+            print(f'MISSING: {test_plan_path}')
+            missing.append(test_plan_path)
 sys.exit(1 if missing else 0)
 PYTHON
-    if [[ $? -eq 0 ]]; then
+    then
         record_pass "test_plan_coverage"
         ok "All in-flight stories have test plans"
     else


### PR DESCRIPTION
Three bugs caused the Trace Validation CI check to always fail on any PR
touching .github/skills/**:

1. Phase 3 epic.stories[] contains string slugs (e.g. 'p3.1a'), not objects.
   Calling story.get('slug') on a string raises AttributeError.

2. Phase 3 story slugs are short ('p3.1a') while filenames use the full name
   ('p3.1a-trace-commit-observability-test-plan.md'). Path construction was
   wrong, so even if (1) was fixed, test plans would incorrectly appear missing.

3. python3 exit-code 1 with the 'python3 ...; if [[ \True -eq 0 ]]' pattern
   triggers set -euo pipefail and kills the script before the if runs.

Fix:
- Collect story objects from feature.stories[] first (Phase 3+), falling back
  to epic-nested story objects (Phase 1/2). Skip string slugs in epics.
- Derive the file slug from story.artefact basename (works for both short and
  full slugs).
- Convert to 'if python3 ...; then' syntax to be safe with set -e.
