### PR TITLE
feat: deploy dashboards/ to GitHub Pages (dviz.2)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,43 @@
+name: Deploy dashboards to GitHub Pages
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - 'dashboards/**'
+      - '.github/pipeline-state.json'
+  workflow_dispatch:
+
+permissions:
+  contents:      read
+  pages:         write
+  id-token:      write
+  administration: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+        with:
+          enablement: true
+
+      - name: Upload dashboards/ as Pages artefact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: dashboards/
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
Adds \.github/workflows/pages.yml\ to deploy the \dashboards/\ directory to GitHub Pages on every push to master.

- Triggered on push to master (changes to \dashboards/**\ or \.github/pipeline-state.json\) + manual dispatch
- Uses \ctions/upload-pages-artifact\ + \ctions/deploy-pages\
- Requires GitHub Pages source set to 'GitHub Actions' in repo settings

**One-time repo setting:** Settings → Pages → Source → GitHub Actions