### PR TITLE
fix: remove invalid administration permission from pages workflow

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,43 @@
+name: Deploy dashboards to GitHub Pages
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - 'dashboards/**'
+      - '.github/pipeline-state.json'
+  workflow_dispatch:
+
+permissions:
+  contents:      read
+  pages:         write
+  id-token:      write
+  administration: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+        with:
+          enablement: true
+
+      - name: Upload dashboards/ as Pages artefact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: dashboards/
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -9,10 +9,9 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents:      read
-  pages:         write
-  id-token:      write
-  administration: write
+  contents: read
+  pages:    write
+  id-token: write
 
 concurrency:
   group: pages
@@ -32,6 +31,9 @@ jobs:
         uses: actions/configure-pages@v5
         with:
           enablement: true
+
+      - name: Inject pipeline-state.json for Pages
+        run: cp .github/pipeline-state.json dashboards/pipeline-state.json
 
       - name: Upload dashboards/ as Pages artefact
         uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
Removes the invalid \dministration: write\ GITHUB_TOKEN permission that was causing the workflow to fail immediately (0s) with 'workflow file issue'. Also adds a step to copy \.github/pipeline-state.json\ into \dashboards/\ so the dashboard can fetch it on GitHub Pages.