### PR TITLE
feat(p4-obs-archive): story archive toggle, viz badge, mergeState archived flag

### DIFF
--- a/.github/pipeline-state.schema.json
+++ b/.github/pipeline-state.schema.json
@@ -88,6 +88,7 @@
           },
           "health":   { "type": "string", "enum": ["green", "amber", "red"] },
           "updatedAt":{ "type": "string", "format": "date-time" },
+          "archivedStoryCount": { "type": "integer", "description": "Number of stories moved to archive for this feature by archiveStories(). Set by scripts/archive-completed-features.js." },
           "blocker":  { "type": "string", "description": "Human-readable blocker description if health is red" },
           "traceStatus": { "type": "string", "enum": ["not-run", "passed", "has-findings"], "description": "Traceability check result written by /trace skill" },
           "guardrails": {

--- a/dashboards/index.html
+++ b/dashboards/index.html
@@ -417,6 +417,22 @@
     box-shadow: 0 0 0 2px color-mix(in oklch, var(--fail) 15%, transparent);
   }
 
+  /* ── Archive toggle (p4-obs-archive) ── */
+  .story-row-archived { display: none; }
+  .story-row-archived.show-archived { display: inline-flex; opacity: 0.45; color: var(--ink-3); }
+  .epic-archive-badge {
+    font-family: var(--font-mono);
+    font-size: 9px;
+    padding: 1px 5px;
+    border: 1px solid var(--rule);
+    color: var(--ink-4);
+    background: var(--paper-2);
+    cursor: default;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  }
+  .epic-archive-badge:hover { background: var(--paper-3); color: var(--ink-3); }
+
   /* current phase (cycle's active) highlight column */
   .epic-row .cell.cur-col {
     box-shadow: inset 0 2px 0 var(--gate), inset 0 -2px 0 var(--gate);
@@ -1024,6 +1040,10 @@ const PHASES = [
   { i: "12", key: "improve",       name: "/improve",              loop: "improve" },
 ];
 const PHASE_IDX = Object.fromEntries(PHASES.map((p, i) => [p.key, i]));
+
+// ── Archive toggle — read ?showArchived=true from URL (p4-obs-archive) ──
+const SHOW_ARCHIVED = typeof window !== 'undefined' &&
+  new URLSearchParams(window.location.search).get('showArchived') === 'true';
 
 // ═══════════════════════════════════════════════════════════════════
 // CYCLES + EPICS — populated by pipeline-adapter.js when served via HTTP;
@@ -2228,6 +2248,10 @@ function EpicRow({ cycle, epic, selected, onSelect, onOpenDoc }) {
   const curN = epic.stories.filter(s => s.state === "current").length;
   const blkN = epic.stories.filter(s => s.state === "blocked").length;
 
+  // Archive badge: read archivedStoryCount from window.PIPELINE_STATE (p4-obs-archive)
+  const featureState = (window.PIPELINE_STATE && window.PIPELINE_STATE.features || []).find(f => f.slug === epic.cycleId);
+  const archivedCount = featureState && featureState.archivedStoryCount ? featureState.archivedStoryCount : 0;
+
   const openEpicDoc = (e) => { e.stopPropagation(); onOpenDoc(docForEpic(epic)); };
   const openStoryDoc = (e, s) => { e.stopPropagation(); onOpenDoc(docForStory(s, epic)); };
 
@@ -2249,6 +2273,11 @@ function EpicRow({ cycle, epic, selected, onSelect, onOpenDoc }) {
             })}
           </span>
           {blkN > 0 && <span style={{color:"var(--fail)"}}>{blkN} blk</span>}
+          {archivedCount > 0 && (
+            <span className="epic-archive-badge" title={SHOW_ARCHIVED ? "Showing archived stories" : "Pass ?showArchived=true to show archived stories"}>
+              {archivedCount} archived
+            </span>
+          )}
         </div>
       </div>
       {PHASES.map(p => {
@@ -2259,18 +2288,22 @@ function EpicRow({ cycle, epic, selected, onSelect, onOpenDoc }) {
           <div key={p.key}
                className={`cell ${cls} ${isCur ? "cur-col" : ""}`}
                data-loop={p.loop}>
-            {here.map(s => (
-              <span key={s.id}
-                    className={`story ${s.state}`}
-                    data-clickable="true"
-                    onClick={(e) => openStoryDoc(e, s)}
-                    title={`${s.id}${s.name ? " · " + s.name : ""} · ${s.state}${s.blockerId ? " · " + s.blockerId : ""}${s.prUrl ? " · PR" : ""}${s.dodStatus === "complete" ? " · DoD ✓" : ""} · click to open doc`}>
-                {s.state === "blocked" && <span className="dot-b" />}
-                {s.id}
-                {s.dodStatus === "complete" && <span style={{fontSize:9, marginLeft:2, opacity:0.7}}>✓</span>}
-                {s.prUrl && <span style={{fontSize:9, marginLeft:2, opacity:0.7}}>⬤</span>}
-              </span>
-            ))}
+            {here.map(s => {
+              const isArchived = s.archived === true;
+              const archivedCls = isArchived ? (" story-row-archived" + (SHOW_ARCHIVED ? " show-archived" : "")) : "";
+              return (
+                <span key={s.id}
+                      className={`story ${s.state}${archivedCls}`}
+                      data-clickable="true"
+                      onClick={(e) => openStoryDoc(e, s)}
+                      title={`${s.id}${s.name ? " · " + s.name : ""} · ${s.state}${s.blockerId ? " · " + s.blockerId : ""}${s.prUrl ? " · PR" : ""}${s.dodStatus === "complete" ? " · DoD ✓" : ""} · click to open doc`}>
+                  {s.state === "blocked" && <span className="dot-b" />}
+                  {s.id}
+                  {s.dodStatus === "complete" && <span style={{fontSize:9, marginLeft:2, opacity:0.7}}>✓</span>}
+                  {s.prUrl && <span style={{fontSize:9, marginLeft:2, opacity:0.7}}>⬤</span>}
+                </span>
+              );
+            })}
           </div>
         );
       })}

--- a/scripts/archive-completed-features.js
+++ b/scripts/archive-completed-features.js
@@ -126,21 +126,73 @@ function mergeState(activeData, archiveData) {
 
   for (const archFeature of archiveData.features) {
     if (archFeature.completedStories && activeSlugs.has(archFeature.slug)) {
-      // Partial archive — merge completed stories back into the active feature
+      // Old-style partial archive — merge completed stories back with archived: true
       const activeFeature = merged.features.find(f => f.slug === archFeature.slug);
       if (activeFeature) {
+        const reconstituted = (archFeature.completedStories || []).map(s => Object.assign({}, s, { archived: true }));
         activeFeature.stories = [
-          ...(archFeature.completedStories || []),
+          ...reconstituted,
+          ...(activeFeature.stories || [])
+        ];
+      }
+    } else if (archFeature.stories && activeSlugs.has(archFeature.slug)) {
+      // New-style archiveStories() format — merge back with archived: true
+      const activeFeature = merged.features.find(f => f.slug === archFeature.slug);
+      if (activeFeature) {
+        const reconstituted = archFeature.stories.map(s => Object.assign({}, s, { archived: true }));
+        activeFeature.stories = [
+          ...reconstituted,
           ...(activeFeature.stories || [])
         ];
       }
     } else if (!activeSlugs.has(archFeature.slug)) {
-      // Fully archived feature — add to merged list
+      // Fully archived feature — add to merged list as-is
       merged.features.unshift(archFeature);
     }
   }
 
   return merged;
+}
+
+// ── archiveStories ────────────────────────────────────────────────
+// In-memory story-level archive. Moves completed stories from the active
+// feature to an archive entry. Does NOT write to disk.
+//
+// @param {object} activeState  — full pipeline-state.json object (deep-cloned)
+// @param {object} archiveState — existing archive object (or {} for new)
+// @param {string} featureSlug  — slug of the feature to archive stories from
+// @returns {{ active: object, archive: object }}
+function archiveStories(activeState, archiveState, featureSlug) {
+  const active  = JSON.parse(JSON.stringify(activeState));
+  const archive = JSON.parse(JSON.stringify(archiveState || {}));
+
+  if (!archive.features) archive.features = [];
+
+  const feature = (active.features || []).find(f => f.slug === featureSlug);
+  if (!feature) return { active, archive };
+
+  const stories   = feature.stories || [];
+  const completed = stories.filter(s => isStoryCompleted(s));
+  const remaining = stories.filter(s => !isStoryCompleted(s));
+
+  if (completed.length === 0) return { active, archive };
+
+  // Add completed stories to archive entry for this feature
+  let archEntry = archive.features.find(f => f.slug === featureSlug);
+  if (!archEntry) {
+    archEntry = { slug: featureSlug, stories: [] };
+    archive.features.push(archEntry);
+  }
+  if (!archEntry.stories) archEntry.stories = [];
+  for (const s of completed) {
+    archEntry.stories.push(JSON.parse(JSON.stringify(s)));
+  }
+
+  // Update active feature: remove completed stories, record count
+  feature.stories = remaining;
+  feature.archivedStoryCount = (feature.archivedStoryCount || 0) + completed.length;
+
+  return { active, archive };
 }
 
 // CLI mode
@@ -152,4 +204,4 @@ if (require.main === module) {
   console.log(`Archive: ${result.archivePath}`);
 }
 
-module.exports = { archive, mergeState };
+module.exports = { archive, mergeState, archiveStories, isStoryCompleted, isFeatureFullyCompleted };

--- a/tests/check-p4-obs-archive.js
+++ b/tests/check-p4-obs-archive.js
@@ -1,0 +1,259 @@
+#!/usr/bin/env node
+// check-p4-obs-archive.js — governance tests for p4-obs-archive story
+// 12 tests: T1–T10, T-NFR1, T-NFR2
+// No external dependencies — Node.js built-ins only.
+'use strict';
+
+const fs   = require('fs');
+const path = require('path');
+
+const SUITE = '[p4-obs-archive]';
+let passed = 0;
+let failed = 0;
+
+function assert(condition, label) {
+  if (condition) { console.log(`  \u2713 ${label}`); passed++; }
+  else           { console.log(`  \u2717 ${label}`); failed++; }
+}
+
+function loadArchiveMod() {
+  const p = path.join(__dirname, '..', 'scripts', 'archive-completed-features.js');
+  if (!fs.existsSync(p)) return null;
+  delete require.cache[require.resolve(p)];
+  return require(p);
+}
+
+const archiveMod = loadArchiveMod();
+
+if (!archiveMod) {
+  console.log(`${SUITE} SKIP: archive module not found`);
+  process.exit(1);
+}
+
+// ── Fixtures ──────────────────────────────────────────────────────
+
+function makeActiveState(stories) {
+  return {
+    version: '1',
+    features: [
+      {
+        slug: 'slug-a',
+        name: 'Feature A',
+        stage: 'subagent-execution',
+        health: 'green',
+        track: 'standard',
+        stories: stories
+      }
+    ]
+  };
+}
+
+const doneStory = {
+  id: 'done-story-1',
+  stage: 'definition-of-done',
+  state: 'done',
+  dodStatus: 'complete',
+  dodAt: '2025-01-10T00:00:00.000Z'
+};
+
+const activeStory = {
+  id: 'active-story-1',
+  stage: 'subagent-execution',
+  state: 'current',
+  dodStatus: 'not-started'
+};
+
+// ── T1 — archiveStories removes done story from active ────────────
+console.log(`${SUITE} T1 \u2014 archiveStories removes done story from active`);
+{
+  if (typeof archiveMod.archiveStories !== 'function') {
+    assert(false, 'T1: archiveStories not exported');
+  } else {
+    const active  = makeActiveState([doneStory, activeStory]);
+    const result  = archiveMod.archiveStories(active, {}, 'slug-a');
+    const activeF = result.active.features.find(f => f.slug === 'slug-a');
+    const hasFullDoneObj = activeF.stories.some(s => typeof s === 'object' && s.id === 'done-story-1' && s.dodStatus === 'complete');
+    assert(!hasFullDoneObj, 'T1a: done story no longer in active as full object');
+    assert(activeF.stories.some(s => s.id === 'active-story-1'), 'T1b: active story still present');
+  }
+}
+
+// ── T2 — archivedStoryCount set on active feature ─────────────────
+console.log(`${SUITE} T2 \u2014 archivedStoryCount set on active feature`);
+{
+  if (typeof archiveMod.archiveStories !== 'function') {
+    assert(false, 'T2: archiveStories not exported');
+  } else {
+    const active  = makeActiveState([doneStory, activeStory]);
+    const result  = archiveMod.archiveStories(active, {}, 'slug-a');
+    const activeF = result.active.features.find(f => f.slug === 'slug-a');
+    assert(activeF.archivedStoryCount === 1, 'T2: archivedStoryCount is 1 after archiving 1 story');
+  }
+}
+
+// ── T3 — archive contains the archived story ─────────────────────
+console.log(`${SUITE} T3 \u2014 archive contains archived story`);
+{
+  if (typeof archiveMod.archiveStories !== 'function') {
+    assert(false, 'T3: archiveStories not exported');
+  } else {
+    const active   = makeActiveState([doneStory, activeStory]);
+    const result   = archiveMod.archiveStories(active, {}, 'slug-a');
+    const archF    = (result.archive.features || []).find(f => f.slug === 'slug-a');
+    assert(archF && archF.stories && archF.stories.length === 1, 'T3a: archive entry has 1 story');
+    assert(archF && archF.stories[0].id === 'done-story-1', 'T3b: archived story id correct');
+  }
+}
+
+// ── T4 — mergeState adds archived: true ──────────────────────────
+console.log(`${SUITE} T4 \u2014 mergeState adds archived: true`);
+{
+  if (typeof archiveMod.archiveStories !== 'function') {
+    assert(false, 'T4: archiveStories not exported'); assert(false, 'T4b: skip'); assert(false, 'T4c: skip');
+  } else {
+  const result  = archiveMod.archiveStories(makeActiveState([doneStory, activeStory]), {}, 'slug-a');
+  // Merge archive back into a fresh active state that has only the in-flight story
+  const fresh   = makeActiveState([activeStory]);
+  const merged  = archiveMod.mergeState(fresh, result.archive);
+  const mergedF = merged.features.find(f => f.slug === 'slug-a');
+  const archivedStory = mergedF.stories.find(s => s.id === 'done-story-1');
+  assert(archivedStory !== undefined, 'T4a: archived story reconstituted in merged state');
+  assert(archivedStory && archivedStory.archived === true, 'T4b: archived story has archived: true');
+  } // end if archiveStories
+}
+
+// ── T5 — round-trip fidelity with 3 stories ──────────────────────
+console.log(`${SUITE} T5 \u2014 round-trip fidelity`);
+{
+  if (typeof archiveMod.archiveStories !== 'function') {
+    assert(false, 'T5: archiveStories not exported'); assert(false, 'T5b-e: skip');
+  } else {
+  const doneStory2 = { id: 'done-story-2', stage: 'definition-of-done', dodStatus: 'complete', name: 'Done 2', myField: 'xyz' };
+  const initial    = makeActiveState([doneStory, doneStory2, activeStory]);
+  const result     = archiveMod.archiveStories(initial, {}, 'slug-a');
+  const fresh      = makeActiveState([activeStory]);
+  const merged     = archiveMod.mergeState(fresh, result.archive);
+  const mergedF    = merged.features.find(f => f.slug === 'slug-a');
+  assert(mergedF.stories.length === 3, 'T5a: all 3 stories in merged state');
+  assert(mergedF.stories.some(s => s.id === 'done-story-1'),  'T5b: done-story-1 present');
+  assert(mergedF.stories.some(s => s.id === 'done-story-2'),  'T5c: done-story-2 present');
+  assert(mergedF.stories.some(s => s.id === 'active-story-1'), 'T5d: active-story-1 present');
+  // Field fidelity: doneStory2 has myField: 'xyz'
+  const s2 = mergedF.stories.find(s => s.id === 'done-story-2');
+  assert(s2 && s2.myField === 'xyz', 'T5e: original fields preserved in archived story');
+  } // end if archiveStories
+}
+
+// ── T6 — index.html contains badge logic ─────────────────────────
+console.log(`${SUITE} T6 \u2014 index.html contains archive badge logic`);
+{
+  const htmlPath = path.join(__dirname, '..', 'dashboards', 'index.html');
+  if (!fs.existsSync(htmlPath)) {
+    assert(false, 'T6: index.html not found');
+  } else {
+    const html = fs.readFileSync(htmlPath, 'utf8');
+    assert(html.includes('archivedStoryCount'), 'T6a: index.html references archivedStoryCount');
+    assert(html.includes('epic-archive-badge'),  'T6b: index.html has epic-archive-badge class');
+    assert(html.includes('archived'),            'T6c: index.html has archived rendering logic');
+  }
+}
+
+// ── T7 — index.html has story-row-archived hidden by default ─────
+console.log(`${SUITE} T7 \u2014 index.html hides archived rows by default`);
+{
+  const htmlPath = path.join(__dirname, '..', 'dashboards', 'index.html');
+  if (!fs.existsSync(htmlPath)) {
+    assert(false, 'T7: index.html not found');
+  } else {
+    const html = fs.readFileSync(htmlPath, 'utf8');
+    assert(html.includes('story-row-archived'), 'T7a: story-row-archived class defined');
+    assert(/story-row-archived[^}]*display\s*:\s*none/.test(html.replace(/\n/g, ' ')), 'T7b: story-row-archived has display:none');
+  }
+}
+
+// ── T8 — index.html handles showArchived query param ─────────────
+console.log(`${SUITE} T8 \u2014 index.html handles showArchived query param`);
+{
+  const htmlPath = path.join(__dirname, '..', 'dashboards', 'index.html');
+  if (!fs.existsSync(htmlPath)) {
+    assert(false, 'T8: index.html not found');
+  } else {
+    const html = fs.readFileSync(htmlPath, 'utf8');
+    assert(html.includes('showArchived'), 'T8: index.html contains showArchived toggle logic');
+  }
+}
+
+// ── T9 — index.html has muted/opacity style for archived rows ────
+console.log(`${SUITE} T9 \u2014 index.html has muted style for archived rows`);
+{
+  const htmlPath = path.join(__dirname, '..', 'dashboards', 'index.html');
+  if (!fs.existsSync(htmlPath)) {
+    assert(false, 'T9: index.html not found');
+  } else {
+    const html = fs.readFileSync(htmlPath, 'utf8');
+    const hasMutedStyle = html.includes('story-archived-visible') || html.includes('show-archived');
+    assert(hasMutedStyle, 'T9a: archived-visible style class present');
+    assert(html.includes('opacity'), 'T9b: opacity style applied to visible archived rows');
+  }
+}
+
+// ── T10 — large fixture (55 stories) handles archiveStories + mergeState ─
+console.log(`${SUITE} T10 \u2014 large fixture 55 stories`);
+{
+  if (typeof archiveMod.archiveStories !== 'function') {
+    assert(false, 'T10: archiveStories not exported');
+  } else {
+    // Build 5 features × 11 stories each (10 done + 1 active)
+    const features = [];
+    for (let i = 0; i < 5; i++) {
+      const stories = [];
+      for (let j = 0; j < 10; j++) {
+        stories.push({ id: 'f' + i + 's' + j, dodStatus: 'complete', stage: 'definition-of-done', state: 'done' });
+      }
+      stories.push({ id: 'f' + i + 'sa', dodStatus: 'not-started', stage: 'subagent-execution', state: 'current' });
+      features.push({ slug: 'feat-' + i, name: 'Feature ' + i, stage: 'subagent-execution', health: 'green', track: 'standard', stories });
+    }
+    const bigActive = { version: '1', features };
+    let archive = {};
+    let current = JSON.parse(JSON.stringify(bigActive));
+    let threw = false;
+    try {
+      for (let i = 0; i < 5; i++) {
+        const result = archiveMod.archiveStories(current, archive, 'feat-' + i);
+        current = result.active;
+        archive = result.archive;
+      }
+    } catch (e) {
+      threw = true;
+    }
+    assert(!threw, 'T10a: no error thrown for 55-story fixture');
+    // All 5 features still present in merged state
+    const merged = archiveMod.mergeState(current, archive);
+    assert(merged.features.length === 5, 'T10b: all 5 features in merged result');
+  }
+}
+
+// ── T-NFR1 — schema.json contains archivedStoryCount ─────────────
+console.log(`${SUITE} T-NFR1 \u2014 schema has archivedStoryCount`);
+{
+  const schemaPath = path.join(__dirname, '..', '.github', 'pipeline-state.schema.json');
+  if (!fs.existsSync(schemaPath)) {
+    assert(false, 'T-NFR1: schema file not found');
+  } else {
+    const schema = fs.readFileSync(schemaPath, 'utf8');
+    assert(schema.includes('archivedStoryCount'), 'T-NFR1: archivedStoryCount present in schema');
+  }
+}
+
+// ── T-NFR2 — no new .js files in dashboards/ ─────────────────────
+console.log(`${SUITE} T-NFR2 \u2014 no new .js files in dashboards/`);
+{
+  const dashDir   = path.join(__dirname, '..', 'dashboards');
+  const jsFiles   = fs.readdirSync(dashDir).filter(f => f.endsWith('.js')).sort();
+  const expected  = ['artefact-content.js', 'artefact-fetcher.js', 'extra-data.js', 'md-renderer.js', 'pipeline-adapter.js'].sort();
+  assert(JSON.stringify(jsFiles) === JSON.stringify(expected), 'T-NFR2: only the 5 original .js files in dashboards/ (got: ' + jsFiles.join(', ') + ')');
+}
+
+// ── Results ───────────────────────────────────────────────────────
+console.log(`${SUITE} Results: ${passed} passed, ${failed} failed`);
+process.exit(failed > 0 ? 1 : 0);


### PR DESCRIPTION
## Story: p4-obs-archive — Story Archive Toggle

Extends `scripts/archive-completed-features.js`:
- `archiveStories(activeState, archiveState, featureSlug)` — in-memory story-level archive (does not write to disk)
- Updated `mergeState()` — reconstitutes archived stories with `archived: true`; handles both old `completedStories` and new `stories` archive formats

Extends `dashboards/index.html`:
- CSS: `.story-row-archived { display: none }` / `.show-archived { opacity: 0.45 }`
- JS: `SHOW_ARCHIVED` const reads `?showArchived=true` from URL query params
- `EpicRow`: reads `archivedStoryCount` from `window.PIPELINE_STATE`, shows `.epic-archive-badge`, applies `.story-row-archived` class to archived stories

Updates `.github/pipeline-state.schema.json`: adds `archivedStoryCount` field.

Covered by `tests/check-p4-obs-archive.js` — 24 assertions, all passing.

**Commit:** 060b4c5
**Story artefact:** `artefacts/2026-04-18-skills-platform-phase4-revised/stories/`

> Draft PR — do not mark ready for review. Do not merge.