### PR TITLE
feat(p4-obs-benefit): benefit comparison artefact writer

### DIFF
--- a/scripts/record-benefit-comparison.js
+++ b/scripts/record-benefit-comparison.js
@@ -1,0 +1,181 @@
+#!/usr/bin/env node
+// record-benefit-comparison.js
+// Records a platform-vs-traditional benefit comparison artefact.
+// No external dependencies — Node.js built-ins only.
+// Security (MC-SEC-02): no credentials, no hardcoded org names.
+'use strict';
+
+const fs   = require('fs');
+const path = require('path');
+
+// ── Helpers ──────────────────────────────────────────────────────
+
+function parseNormsHours(normsPath, featureSlug) {
+  if (!normsPath || !fs.existsSync(normsPath)) return null;
+  try {
+    const lines = fs.readFileSync(normsPath, 'utf8').split('\n');
+    for (const line of lines) {
+      if (line.includes(featureSlug)) {
+        // Find the last column (E3 actuals): look for an hours value like 12.5h
+        const match = line.match(/([\d.]+)\s*h\s*\|?\s*$/);
+        if (match) return parseFloat(match[1]);
+        // Try any column: find all hour values and take the last
+        const allHours = line.match(/([\d.]+)\s*h/g);
+        if (allHours && allHours.length > 0) {
+          return parseFloat(allHours[allHours.length - 1]);
+        }
+      }
+    }
+  } catch (_) {
+    // file read error
+  }
+  return null;
+}
+
+function deltaPercent(platform, traditional) {
+  if (!traditional || traditional === 0) return null;
+  return Math.round((platform - traditional) / traditional * 100);
+}
+
+function countCompleted(state, featureSlug) {
+  const f = (state.features || []).find(f => f.slug === featureSlug);
+  if (!f) return 0;
+  return (f.stories || []).filter(s => s.dodStatus === 'complete').length;
+}
+
+function sumTestCount(state, featureSlug) {
+  const f = (state.features || []).find(f => f.slug === featureSlug);
+  if (!f) return 0;
+  let total = 0;
+  for (const s of (f.stories || [])) {
+    if (s.testPlan) total += s.testPlan.totalTests || 0;
+  }
+  return total;
+}
+
+// ── recordComparison ─────────────────────────────────────────────
+
+function recordComparison(inputs, state, opts) {
+  opts = opts || {};
+
+  const featureSlug      = inputs.featureSlug;
+  const workspaceDir     = opts.workspaceDir || path.join(process.cwd(), 'workspace');
+  const normsPath        = opts.normsPath != null
+    ? opts.normsPath
+    : path.join(workspaceDir, 'estimation-norms.md');
+
+  const platformCycleDays   = inputs.platformCycleDays   != null ? inputs.platformCycleDays   : null;
+  const traditionalCycleDays = inputs.traditionalCycleDays != null ? inputs.traditionalCycleDays : null;
+  const platformStoryCount  = inputs.platformStoryCount  != null ? inputs.platformStoryCount  : countCompleted(state, featureSlug);
+  const platformTestCount   = inputs.platformTestCount   != null ? inputs.platformTestCount   : sumTestCount(state, featureSlug);
+  const tradOpHours         = inputs.traditionalOperatorHours != null ? inputs.traditionalOperatorHours : null;
+
+  const platOpHours    = parseNormsHours(normsPath, featureSlug);
+  const experimentRef  = inputs.experimentRef != null ? inputs.experimentRef : null;
+  const reportDate     = new Date().toISOString().slice(0, 10);
+  const delta          = platformCycleDays != null && traditionalCycleDays != null
+    ? deltaPercent(platformCycleDays, traditionalCycleDays)
+    : null;
+  const deltaStr       = delta != null ? delta + '%' : 'n/a';
+  const hoursStr       = platOpHours != null ? String(platOpHours) : 'null';
+
+  // ── Build YAML front-matter ──────────────────────────────────
+  const fm = [
+    '---',
+    'feature_slug: '                       + featureSlug,
+    'report_date: '                        + reportDate,
+    'platform_cycle_days: '               + (platformCycleDays  != null ? platformCycleDays  : 'null'),
+    'traditional_cycle_days: '            + (traditionalCycleDays != null ? traditionalCycleDays : 'null'),
+    'platform_operator_hours: '           + hoursStr,
+    'traditional_operator_hours_estimate: ' + (tradOpHours != null ? tradOpHours : 'null'),
+    'platform_story_count: '              + (platformStoryCount != null ? platformStoryCount : 'null'),
+    'platform_test_count: '               + (platformTestCount  != null ? platformTestCount  : 'null'),
+    'experiment_ref: '                    + (experimentRef != null ? experimentRef : 'null'),
+    'delta_percent: '                     + (delta != null ? delta : 'null'),
+    '---'
+  ].join('\n');
+
+  // ── Build body ───────────────────────────────────────────────
+  const body = [
+    '',
+    '# Benefit Comparison: ' + featureSlug,
+    '',
+    '## Cycle Time Comparison',
+    '',
+    '| Metric | Platform | Traditional |',
+    '|--------|----------|-------------|',
+    '| Cycle days | ' + (platformCycleDays != null ? platformCycleDays : 'n/a') + ' | ' + (traditionalCycleDays != null ? traditionalCycleDays : 'n/a') + ' |',
+    '| Delta | ' + deltaStr + ' | — |',
+    '| Stories completed | ' + (platformStoryCount != null ? platformStoryCount : 'n/a') + ' | — |',
+    '| Tests | ' + (platformTestCount != null ? platformTestCount : 'n/a') + ' | — |',
+    '| Operator hours | ' + hoursStr + ' | ' + (tradOpHours != null ? tradOpHours : 'n/a') + ' |',
+    ''
+  ].join('\n');
+
+  const content = fm + body;
+
+  // ── Write to disk ────────────────────────────────────────────
+  const expDir   = path.join(workspaceDir, 'experiments');
+  if (!fs.existsSync(expDir)) fs.mkdirSync(expDir, { recursive: true });
+  const outPath  = path.join(expDir, 'benefit-comparison-' + featureSlug + '.md');
+  fs.writeFileSync(outPath, content, 'utf8');
+
+  return outPath;
+}
+
+// ── generateSummary ──────────────────────────────────────────────
+
+function generateSummary(experimentsDir) {
+  if (!fs.existsSync(experimentsDir)) return '| Feature | Platform cycle (days) | Traditional estimate (days) | Delta % | Platform tests | Operator hours saved |\n|---------|----------------------|-----------------------------|---------|----------------|---------------------|\n';
+
+  const files = fs.readdirSync(experimentsDir)
+    .filter(f => f.startsWith('benefit-comparison-') && f.endsWith('.md'))
+    .sort();
+
+  const rows = [];
+  for (const file of files) {
+    const content = fs.readFileSync(path.join(experimentsDir, file), 'utf8');
+    const parts   = content.split('---');
+    if (parts.length < 2) continue;
+    const fm      = parts[1];
+    const data    = {};
+    for (const line of fm.split('\n')) {
+      const idx = line.indexOf(':');
+      if (idx < 0) continue;
+      const key = line.slice(0, idx).trim();
+      const val = line.slice(idx + 1).trim();
+      data[key] = val;
+    }
+    const slug         = data['feature_slug']                    || '';
+    const platCycle    = data['platform_cycle_days']             || 'n/a';
+    const tradCycle    = data['traditional_cycle_days']          || 'n/a';
+    const delta        = data['delta_percent'] != null ? data['delta_percent'] + '%' : 'n/a';
+    const tests        = data['platform_test_count']             || 'n/a';
+    const platOpH      = data['platform_operator_hours']         || 'n/a';
+    const tradOpH      = data['traditional_operator_hours_estimate'] || 'n/a';
+    const hoursSaved   = (platOpH !== 'n/a' && tradOpH !== 'n/a' && platOpH !== 'null' && tradOpH !== 'null')
+      ? String(parseFloat(tradOpH) - parseFloat(platOpH))
+      : 'n/a';
+    rows.push(`| ${slug} | ${platCycle} | ${tradCycle} | ${delta} | ${tests} | ${hoursSaved} |`);
+  }
+
+  const header = '| Feature | Platform cycle (days) | Traditional estimate (days) | Delta % | Platform tests | Operator hours saved |';
+  const sep    = '|---------|----------------------|-----------------------------|---------|----------------|---------------------|';
+  return [header, sep, ...rows].join('\n');
+}
+
+// ── CLI ──────────────────────────────────────────────────────────
+
+if (require.main === module) {
+  const args    = process.argv.slice(2);
+  const summIdx = args.indexOf('--summary');
+  if (summIdx !== -1) {
+    const expDir = args[summIdx + 1] || path.join(process.cwd(), 'workspace', 'experiments');
+    console.log(generateSummary(expDir));
+    process.exit(0);
+  }
+  console.error('Usage: node record-benefit-comparison.js --summary [experimentsDir]');
+  process.exit(1);
+}
+
+module.exports = { recordComparison, generateSummary };

--- a/tests/check-p4-obs-benefit.js
+++ b/tests/check-p4-obs-benefit.js
@@ -1,0 +1,286 @@
+#!/usr/bin/env node
+// check-p4-obs-benefit.js — governance tests for scripts/record-benefit-comparison.js
+// 12 tests: T1–T10, T-NFR1, T-NFR2
+// No external dependencies — Node.js built-ins only.
+'use strict';
+
+const fs   = require('fs');
+const path = require('path');
+const os   = require('os');
+
+const SUITE = '[p4-obs-benefit]';
+let passed = 0;
+let failed = 0;
+
+function assert(condition, label) {
+  if (condition) { console.log(`  \u2713 ${label}`); passed++; }
+  else           { console.log(`  \u2717 ${label}`); failed++; }
+}
+
+function loadMod() {
+  const p = path.join(__dirname, '..', 'scripts', 'record-benefit-comparison.js');
+  if (!fs.existsSync(p)) return null;
+  delete require.cache[require.resolve(p)];
+  return require(p);
+}
+
+const mod = loadMod();
+
+// ── T1 — module exports ───────────────────────────────────────────
+console.log(`${SUITE} T1 \u2014 module exports`);
+assert(mod !== null, 'T1a: module exists');
+assert(mod && typeof mod.recordComparison === 'function',  'T1b: exports recordComparison');
+assert(mod && typeof mod.generateSummary  === 'function', 'T1c: exports generateSummary');
+
+if (!mod) {
+  console.log(`${SUITE} Results: ${passed} passed, ${failed} failed`);
+  process.exit(1);
+}
+
+// ── Shared fixtures ───────────────────────────────────────────────
+const baseInputs = {
+  featureSlug:               'slug-a',
+  platformCycleDays:         10,
+  traditionalCycleDays:      30,
+  platformStoryCount:        5,
+  platformTestCount:         40,
+  traditionalOperatorHours:  80
+};
+
+const baseState = {
+  version: '1',
+  features: [
+    {
+      slug: 'slug-a',
+      name: 'Feature A',
+      stage: 'definition-of-done',
+      stories: [
+        { id: 's1', dodStatus: 'complete' },
+        { id: 's2', dodStatus: 'complete' }
+      ],
+      epics: []
+    }
+  ]
+};
+
+// Helper: create temp workspace dir
+function mkTmp() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'obs-benefit-'));
+}
+
+// ── T1 ── already done above ──────────────────────────────────────
+
+// ── T2 — file created at expected path ───────────────────────────
+console.log(`${SUITE} T2 \u2014 file created at expected path`);
+{
+  const tmp = mkTmp();
+  mod.recordComparison(baseInputs, baseState, { workspaceDir: tmp });
+  const expected = path.join(tmp, 'experiments', 'benefit-comparison-slug-a.md');
+  assert(fs.existsSync(expected), 'T2: file created at workspace/experiments/benefit-comparison-<slug>.md');
+  try { fs.rmSync(tmp, { recursive: true, force: true }); } catch (_) {}
+}
+
+// ── T3 — front-matter has all 8 required fields ───────────────────
+console.log(`${SUITE} T3 \u2014 front-matter has all 8 required fields`);
+{
+  const tmp      = mkTmp();
+  const out      = mod.recordComparison(baseInputs, baseState, { workspaceDir: tmp });
+  const content  = fs.readFileSync(path.join(tmp, 'experiments', 'benefit-comparison-slug-a.md'), 'utf8');
+  const REQUIRED = [
+    'feature_slug',
+    'report_date',
+    'platform_cycle_days',
+    'traditional_cycle_days',
+    'platform_operator_hours',
+    'traditional_operator_hours_estimate',
+    'platform_story_count',
+    'platform_test_count'
+  ];
+  for (const field of REQUIRED) {
+    assert(content.includes(field), 'T3: front-matter has ' + field);
+  }
+  try { fs.rmSync(tmp, { recursive: true, force: true }); } catch (_) {}
+}
+
+// ── T4 — body contains comparison table ──────────────────────────
+console.log(`${SUITE} T4 \u2014 body contains comparison table`);
+{
+  const tmp     = mkTmp();
+  mod.recordComparison(baseInputs, baseState, { workspaceDir: tmp });
+  const content = fs.readFileSync(path.join(tmp, 'experiments', 'benefit-comparison-slug-a.md'), 'utf8');
+  assert(content.includes('Platform')    && content.includes('Traditional'), 'T4: table has Platform + Traditional columns');
+  try { fs.rmSync(tmp, { recursive: true, force: true }); } catch (_) {}
+}
+
+// ── T5 — delta calculation -67% ──────────────────────────────────
+console.log(`${SUITE} T5 \u2014 delta calculation -67%`);
+{
+  const tmp      = mkTmp();
+  const inputs   = Object.assign({}, baseInputs, { platformCycleDays: 10, traditionalCycleDays: 30 });
+  mod.recordComparison(inputs, baseState, { workspaceDir: tmp });
+  const content  = fs.readFileSync(path.join(tmp, 'experiments', 'benefit-comparison-slug-a.md'), 'utf8');
+  assert(content.includes('-67%'), 'T5: delta is -67%');
+  try { fs.rmSync(tmp, { recursive: true, force: true }); } catch (_) {}
+}
+
+// ── T6 — generateSummary 2 rows ───────────────────────────────────
+console.log(`${SUITE} T6 \u2014 generateSummary produces 2 data rows`);
+{
+  const tmp   = mkTmp();
+  const expDir = path.join(tmp, 'experiments');
+  fs.mkdirSync(expDir, { recursive: true });
+  // Write two fixture files
+  const f1 = [
+    '---',
+    'feature_slug: feat-a',
+    'report_date: 2025-01-01',
+    'platform_cycle_days: 10',
+    'traditional_cycle_days: 30',
+    'platform_operator_hours: 8',
+    'traditional_operator_hours_estimate: 40',
+    'platform_story_count: 5',
+    'platform_test_count: 30',
+    'delta_percent: -67',
+    '---',
+    '',
+    '## Summary'
+  ].join('\n');
+  const f2 = [
+    '---',
+    'feature_slug: feat-b',
+    'report_date: 2025-01-08',
+    'platform_cycle_days: 15',
+    'traditional_cycle_days: 45',
+    'platform_operator_hours: 12',
+    'traditional_operator_hours_estimate: 60',
+    'platform_story_count: 8',
+    'platform_test_count: 50',
+    'delta_percent: -67',
+    '---',
+    '',
+    '## Summary'
+  ].join('\n');
+  fs.writeFileSync(path.join(expDir, 'benefit-comparison-feat-a.md'), f1);
+  fs.writeFileSync(path.join(expDir, 'benefit-comparison-feat-b.md'), f2);
+  const summary = mod.generateSummary(expDir);
+  // Count data rows (lines with |feat-)
+  const dataRows = summary.split('\n').filter(l => l.includes('feat-'));
+  assert(dataRows.length >= 2, 'T6: summary has 2 data rows');
+  try { fs.rmSync(tmp, { recursive: true, force: true }); } catch (_) {}
+}
+
+// ── T7 — generateSummary table header has all 6 columns ──────────
+console.log(`${SUITE} T7 \u2014 generateSummary header has 6 columns`);
+{
+  const tmp    = mkTmp();
+  const expDir = path.join(tmp, 'experiments');
+  fs.mkdirSync(expDir, { recursive: true });
+  const fixture = [
+    '---',
+    'feature_slug: feat-x',
+    'report_date: 2025-01-01',
+    'platform_cycle_days: 5',
+    'traditional_cycle_days: 20',
+    'platform_operator_hours: 4',
+    'traditional_operator_hours_estimate: 30',
+    'platform_story_count: 3',
+    'platform_test_count: 20',
+    'delta_percent: -75',
+    '---'
+  ].join('\n');
+  fs.writeFileSync(path.join(expDir, 'benefit-comparison-feat-x.md'), fixture);
+  const summary = mod.generateSummary(expDir);
+  const COLS = ['Feature', 'Platform cycle', 'Traditional', 'Delta', 'Platform tests', 'Operator hours'];
+  for (const col of COLS) {
+    assert(summary.includes(col), 'T7: header has ' + col);
+  }
+  try { fs.rmSync(tmp, { recursive: true, force: true }); } catch (_) {}
+}
+
+// ── T8 — experiment_ref set when provided ─────────────────────────
+console.log(`${SUITE} T8 \u2014 experiment_ref set when provided`);
+{
+  const tmp    = mkTmp();
+  const inputs = Object.assign({}, baseInputs, { experimentRef: 'EXP-2025-01' });
+  mod.recordComparison(inputs, baseState, { workspaceDir: tmp });
+  const content = fs.readFileSync(path.join(tmp, 'experiments', 'benefit-comparison-slug-a.md'), 'utf8');
+  assert(content.includes('EXP-2025-01'), 'T8: experiment_ref value present');
+  try { fs.rmSync(tmp, { recursive: true, force: true }); } catch (_) {}
+}
+
+// ── T9 — experiment_ref null when absent ─────────────────────────
+console.log(`${SUITE} T9 \u2014 experiment_ref null when absent`);
+{
+  const tmp = mkTmp();
+  mod.recordComparison(baseInputs, baseState, { workspaceDir: tmp });
+  const content = fs.readFileSync(path.join(tmp, 'experiments', 'benefit-comparison-slug-a.md'), 'utf8');
+  assert(content.includes('experiment_ref: null'), 'T9: experiment_ref: null when not provided');
+  try { fs.rmSync(tmp, { recursive: true, force: true }); } catch (_) {}
+}
+
+// ── T10 — platform_operator_hours null when normsPath absent ─────
+console.log(`${SUITE} T10 \u2014 operator_hours null when norms absent`);
+{
+  const tmp = mkTmp();
+  mod.recordComparison(baseInputs, baseState, { workspaceDir: tmp, normsPath: '/nonexistent-norms-file-xyz.md' });
+  const content = fs.readFileSync(path.join(tmp, 'experiments', 'benefit-comparison-slug-a.md'), 'utf8');
+  assert(content.includes('platform_operator_hours: null'), 'T10: null when norms file absent');
+  try { fs.rmSync(tmp, { recursive: true, force: true }); } catch (_) {}
+}
+
+// ── T11 — reads hours from norms file ────────────────────────────
+console.log(`${SUITE} T11 \u2014 reads hours from norms file`);
+{
+  const tmp = mkTmp();
+  // Write fixture norms file with slug-a row
+  const normsPath = path.join(tmp, 'estimation-norms.md');
+  const normsContent = [
+    '# Estimation Norms',
+    '',
+    '| Feature | E1 | E2 | E3 actuals |',
+    '|---------|----|----|------------|',
+    '| slug-a  | 8h | 10h | 12.5h     |',
+    '| other   | 5h | 6h  | 7h        |'
+  ].join('\n');
+  fs.writeFileSync(normsPath, normsContent);
+  mod.recordComparison(baseInputs, baseState, { workspaceDir: tmp, normsPath });
+  const content = fs.readFileSync(path.join(tmp, 'experiments', 'benefit-comparison-slug-a.md'), 'utf8');
+  assert(content.includes('12.5'), 'T11: 12.5h read from norms file');
+  try { fs.rmSync(tmp, { recursive: true, force: true }); } catch (_) {}
+}
+
+// ── T-NFR1 — no credentials ───────────────────────────────────────
+console.log(`${SUITE} T-NFR1 \u2014 no credentials in output`);
+{
+  const tmp = mkTmp();
+  mod.recordComparison(baseInputs, baseState, { workspaceDir: tmp });
+  const content = fs.readFileSync(path.join(tmp, 'experiments', 'benefit-comparison-slug-a.md'), 'utf8');
+  assert(!/Bearer\s/i.test(content) && !/password:/i.test(content) && !/secret:/i.test(content), 'T-NFR1: no credentials in file');
+  try { fs.rmSync(tmp, { recursive: true, force: true }); } catch (_) {}
+}
+
+// ── T-NFR2 — front-matter is simple scalars ───────────────────────
+console.log(`${SUITE} T-NFR2 \u2014 front-matter no nested objects`);
+{
+  const tmp = mkTmp();
+  mod.recordComparison(baseInputs, baseState, { workspaceDir: tmp });
+  const content = fs.readFileSync(path.join(tmp, 'experiments', 'benefit-comparison-slug-a.md'), 'utf8');
+  const parts   = content.split('---');
+  if (parts.length >= 3) {
+    const fm = parts[1];
+    const lines = fm.split('\n').filter(l => l.trim());
+    let noNestedObjects = true;
+    for (const line of lines) {
+      if (/^\s+-/.test(line)) noNestedObjects = false;
+      if (/:\s*\{/.test(line))  noNestedObjects = false;
+    }
+    assert(noNestedObjects, 'T-NFR2: no nested objects or arrays in front-matter');
+  } else {
+    assert(false, 'T-NFR2: front-matter not properly delimited');
+  }
+  try { fs.rmSync(tmp, { recursive: true, force: true }); } catch (_) {}
+}
+
+// ── Results ───────────────────────────────────────────────────────
+console.log(`${SUITE} Results: ${passed} passed, ${failed} failed`);
+process.exit(failed > 0 ? 1 : 0);


### PR DESCRIPTION
## Story: p4-obs-benefit — Benefit Comparison Artefact

Implements `scripts/record-benefit-comparison.js` with two exports:
- `recordComparison(inputs, state, opts)` — writes `workspace/experiments/benefit-comparison-<slug>.md` with YAML front-matter (8 required fields) and a comparison table
- `generateSummary(experimentsDir)` — reads all benefit-comparison files and returns a markdown summary table

Delta formula: `Math.round((platform - traditional) / traditional * 100)` — negative = faster.
Reads E3 actuals from norms file via `opts.normsPath` override for test isolation.
No js-yaml dependency — parses YAML with string split only.

Covered by `tests/check-p4-obs-benefit.js` — 27 assertions, all passing.

**Commit:** 81c6b21
**Story artefact:** `artefacts/2026-04-18-skills-platform-phase4-revised/stories/`

> Draft PR — do not mark ready for review. Do not merge.