### PR TITLE
feat: rrc.2 — add Output 10 (constraint-index.md) to /reverse-engineer

### DIFF
--- a/.github/skills/reverse-engineer/SKILL.md
+++ b/.github/skills/reverse-engineer/SKILL.md
@@ -472,7 +472,10 @@ State which outputs you are producing before starting.
 | 7. ESB reading plan | If ACE/IIB dependency detected | Integration team | `artefacts/[system-slug]/extracts/esb-reading-plan.md` |
 | 8. Corpus state | Always (create on INITIAL, update on subsequent passes) | Orchestrator / next pass agent | `artefacts/[system-slug]/corpus-state.md` |
 | 9. Discovery seed | INITIAL or DEEPEN pass, when Q0 is not DEFER | Platform maintainer / /discovery operator | `artefacts/[system-slug]/discovery-seed.md` |
+| 10. Constraint index | INITIAL or DEEPEN pass, when Q0 is not DEFER | Tech lead / delivery operator | `artefacts/[system-slug]/constraint-index.md` |
 
+### Output 10 — constraint-index.md
+rule-id|source-file|confidence|disposition|summary L<layer>[CHANGE-RISK]
 ### Output 9 — discovery-seed.md
 
 Produce at the end of any INITIAL or DEEPEN pass. **Not produced when Q0 outcome is DEFER.**
@@ -592,6 +595,7 @@ If convergence is not met, the completion statement must say so explicitly and r
 
 **VERIFY pass**
 - If any PARITY REQUIRED rule was added, retired, or had its disposition changed since the last pass: update Output 9 (discovery-seed.md) to reflect the change.
+- After a VERIFY pass: update constraint-index.md to reflect any rules whose disposition changed or were retired.
 
 **Stack-specific**
 - If Spring detected: `@Aspect`, `@Scheduled`, `@Transactional` inventory produced

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to this repository will be documented in this file.
 
 ### Added
 
+- **`rrc.2` — Output 10 (`constraint-index.md`) added to `/reverse-engineer` (2026-04-30):** Output 10 row added to outputs table; compact format section added (`rule-id|source-file|confidence|disposition|summary`, rule-id format `L<layer>-<seq>`, `[CHANGE-RISK]` appended to summary when flagged); VERIFY pass quality check instructs updating `constraint-index.md` when rule dispositions change; Output 10 gated — not produced when Q0 outcome is DEFER. SKILL.md 630 lines (≤650 NFR). `check-skill-contracts.js`: 40 skills, 170 contracts OK.
+
 - **`rrc.1` — Output 9 (`discovery-seed.md`) added to `/reverse-engineer` (2026-04-30):** Output 9 row added to outputs table; `### Output 9 — discovery-seed.md` format section added with 4 sections (system name, problem framing, known constraints, personas), mirroring the `/discovery` template; VERIFY pass quality check instructs updating `discovery-seed.md` when any PARITY REQUIRED rule changes; Output 9 gated — not produced when Q0 outcome is DEFER. SKILL.md 626 lines (≤650 NFR). `check-skill-contracts.js`: 40 skills, 170 contracts OK.
 
 


### PR DESCRIPTION
## rrc.2: Add Output 10 — Constraint index

Adds Output 10 instruction block to .github/skills/reverse-engineer/SKILL.md.
Branches from feat/rrc.1 — depends on rrc.1 merge first.

**What changed:**
- Output 10 row added to the outputs table
- constraint-index.md format section: pipe-delimited (rule-id | source-file | confidence | disposition | summary)
- CHANGE-RISK notation: summary column appends [CHANGE-RISK] for flagged rules
- VERIFY pass instruction: update constraint-index.md when dispositions change
- Output 10 gated: not produced when Q0 outcome is DEFER
- Rule-id format: L<layer>-<seq> per DEC-001

**Tests:** all 13 in tests/check-rrc2-constraint-index.js pass; all 10 rrc.1 tests still pass
**NFR:** combined SKILL.md 630 lines (≤650)
**Governance:** check-skill-contracts.js reports 40 skills, 170 contracts OK

Story: artefacts/2026-04-30-reverse-engineer-reference-corpus/stories/rrc.2-constraint-index-output.md
DoR: artefacts/2026-04-30-reverse-engineer-reference-corpus/dor/rrc.2-dor.md