### PR TITLE
feat(wuce.15): artefact writeback with path validation

### DIFF
--- a/src/artefact-path-validator.js
+++ b/src/artefact-path-validator.js
@@ -1,0 +1,12 @@
+'use strict';
+const path = require('path');
+const ARTEFACTS_PREFIX = 'artefacts/';
+
+function validateArtefactPath(inputPath) {
+  if (typeof inputPath !== 'string' || !inputPath) { return false; }
+  if (path.isAbsolute(inputPath)) { return false; }
+  const normalised = path.posix.normalize(inputPath.replace(/\\/g, '/'));
+  return normalised.startsWith(ARTEFACTS_PREFIX);
+}
+
+module.exports = { validateArtefactPath };

--- a/src/scm-adapter.js
+++ b/src/scm-adapter.js
@@ -1,0 +1,39 @@
+'use strict';
+const { validateArtefactPath } = require('./artefact-path-validator');
+
+let _adapterOverride = null;
+function setAdapterForTest(mock) { _adapterOverride = mock; }
+
+function getWuce3Adapter() {
+  if (_adapterOverride) { return _adapterOverride; }
+  return require('./web-ui/artefacts/artefact-adapter');
+}
+
+async function commitArtefact(options) {
+  const { path, content, accessToken, userId, sessionId, skillName } = options;
+  if (!validateArtefactPath(path)) {
+    const err = new Error('INVALID_PATH: path must be under artefacts/');
+    err.code = 'INVALID_PATH';
+    throw err;
+  }
+  const commitMessage = 'artefact: commit /' + skillName + ' session output [' + sessionId + ']';
+  const adapter = getWuce3Adapter();
+  try {
+    const result = await adapter.commitArtefact({
+      path, content, accessToken, commitMessage,
+      author:    { name: userId, email: userId + '@users.noreply.github.com' },
+      committer: { name: userId, email: userId + '@users.noreply.github.com' }
+    });
+    return { sha: result.commit.sha, htmlUrl: result.content.html_url };
+  } catch (err) {
+    if (err.status === 409 || (err.message && err.message.includes('409'))) {
+      const conflictErr = new Error('Artefact already exists \u2014 reload and review before committing');
+      conflictErr.code = 'ARTEFACT_CONFLICT';
+      conflictErr.existingArtefactUrl = err.existingArtefactUrl || null;
+      throw conflictErr;
+    }
+    throw err;
+  }
+}
+
+module.exports = { commitArtefact, setAdapterForTest };

--- a/src/web-ui/artefacts/artefact-adapter.js
+++ b/src/web-ui/artefacts/artefact-adapter.js
@@ -49,4 +49,51 @@ async function fetchArtefact(featureSlug, artefactType, token) {
   return response.text();
 }
 
-module.exports = { fetchArtefact, buildApiBase };
+/**
+ * Commit a pipeline artefact to the GitHub Contents API (create new file).
+ * Uses GITHUB_API_BASE_URL for GHE support (ADR-012).
+ * @param {object} opts
+ * @param {string} opts.path          - repo-relative path, e.g. 'artefacts/slug/file.md'
+ * @param {string} opts.content       - raw file content (will be base64-encoded)
+ * @param {string} opts.accessToken   - OAuth access token
+ * @param {string} opts.commitMessage - commit message string
+ * @param {object} [opts.author]      - { name, email }
+ * @param {object} [opts.committer]   - { name, email }
+ * @returns {Promise<{content: object, commit: object}>} GitHub API response
+ */
+async function commitArtefact({ path: filePath, content, accessToken, commitMessage, author, committer }) {
+  const base  = buildApiBase();
+  const owner = process.env.GITHUB_REPO_OWNER || 'org';
+  const repo  = process.env.GITHUB_REPO_NAME  || 'repo';
+  const url   = `${base}/repos/${owner}/${repo}/contents/${filePath}`;
+
+  const encodedContent = Buffer.from(content).toString('base64');
+  const body = { message: commitMessage, content: encodedContent };
+  if (author)    body.author    = author;
+  if (committer) body.committer = committer;
+
+  const response = await fetch(url, {
+    method: 'PUT',
+    headers: {
+      'Authorization': `token ${accessToken}`,
+      'Content-Type':  'application/json',
+      'Accept':        'application/vnd.github.v3+json',
+      'User-Agent':    'skills-pipeline-web-ui'
+    },
+    body: JSON.stringify(body)
+  });
+
+  if (response.status === 409) {
+    const err = new Error('409: Conflict');
+    err.status = 409;
+    throw err;
+  }
+
+  if (!response.ok) {
+    throw new Error(`GitHub API returned ${response.status} for ${filePath}`);
+  }
+
+  return response.json();
+}
+
+module.exports = { fetchArtefact, commitArtefact, buildApiBase };

--- a/src/web-ui/routes/skill-commit.js
+++ b/src/web-ui/routes/skill-commit.js
@@ -1,0 +1,85 @@
+'use strict';
+
+// skill-commit.js — POST /api/skills/:name/sessions/:id/commit
+// Commits the artefact produced by a completed skill session to the repository.
+// Path is always derived from the skill session — client-supplied paths are ignored.
+
+let _commitFn = null;
+let _sessionRegistry = null;
+
+function setCommitFnForTest(fn) { _commitFn = fn; }
+function setSessionRegistryForTest(registry) { _sessionRegistry = registry; }
+
+function getCommitFn() {
+  return _commitFn || require('../../scm-adapter').commitArtefact;
+}
+
+function getRegistry() {
+  return _sessionRegistry || require('../sessions/skill-session-registry');
+}
+
+/**
+ * handlePostCommit — POST /api/skills/:name/sessions/:id/commit
+ * @param {object} req
+ * @param {object} res
+ */
+async function handlePostCommit(req, res) {
+  const httpSession = req.session;
+  if (!httpSession || !httpSession.accessToken) {
+    res.writeHead(401, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ error: 'Unauthorized' }));
+    return;
+  }
+
+  const sessionId = req.params && req.params.id;
+  const skillName = req.params && req.params.name;
+
+  const registry = getRegistry();
+  const skillSession = registry.getSession(sessionId);
+
+  if (!skillSession || skillSession.userId !== httpSession.userId) {
+    res.writeHead(403, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ error: 'SESSION_FORBIDDEN' }));
+    return;
+  }
+
+  if (skillSession.state !== 'complete') {
+    res.writeHead(400, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ error: 'SESSION_NOT_COMPLETE' }));
+    return;
+  }
+
+  const commitFn = getCommitFn();
+  try {
+    // Path is always derived from the skill session — body.path is deliberately ignored
+    const result = await commitFn({
+      path:        skillSession.artefactPath,
+      content:     skillSession.content,
+      accessToken: httpSession.accessToken,
+      userId:      httpSession.userId,
+      sessionId:   sessionId,
+      skillName:   skillName
+    });
+    res.writeHead(201, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ sha: result.sha, htmlUrl: result.htmlUrl }));
+  } catch (err) {
+    if (err.code === 'INVALID_PATH') {
+      res.writeHead(400, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: err.code, message: err.message }));
+      return;
+    }
+    if (err.code === 'ARTEFACT_CONFLICT') {
+      res.writeHead(409, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({
+        error:               err.code,
+        message:             err.message,
+        existingArtefactUrl: err.existingArtefactUrl || null
+      }));
+      return;
+    }
+    res.writeHead(500, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ error: 'COMMIT_FAILED' }));
+  }
+}
+
+module.exports = { handlePostCommit, setCommitFnForTest, setSessionRegistryForTest };

--- a/src/web-ui/server.js
+++ b/src/web-ui/server.js
@@ -18,6 +18,7 @@ const { handleGetFeatures, handleGetFeatureArtefacts }               = require('
 const { handleGetStatus, handleGetStatusExport }                     = require('./routes/status');
 const { handlePostAnnotation }                                       = require('./routes/annotation');   // wuce.8
 const { handleExecuteSkill }                                         = require('./routes/execute');        // wuce.9
+const { handlePostCommit }                                           = require('./routes/skill-commit');   // wuce.15
 
 const PORT = process.env.PORT || 3000;
 
@@ -104,6 +105,12 @@ async function router(req, res) {
     const skillNameParam = pathname.split('/')[3];
     req.params = { name: skillNameParam };
     await handleExecuteSkill(req, res);
+
+  } else if (pathname.match(/^\/api\/skills\/[^/]+\/sessions\/[^/]+\/commit$/) && req.method === 'POST') {
+    // /api/skills/:name/sessions/:id/commit — parts: ['','api','skills',name,'sessions',id,'commit']
+    const parts = pathname.split('/');
+    req.params = { name: parts[3], id: parts[5] };
+    await handlePostCommit(req, res);
 
   } else {
     // Sign-in page (unauthenticated root)

--- a/src/web-ui/sessions/skill-session-registry.js
+++ b/src/web-ui/sessions/skill-session-registry.js
@@ -1,0 +1,19 @@
+'use strict';
+
+// In-memory skill session registry.
+// Populated by skill execution routes (wuce.13/wuce.9).
+const _sessions = new Map();
+
+function getSession(id) {
+  return _sessions.get(id) || null;
+}
+
+function setSession(id, data) {
+  _sessions.set(id, data);
+}
+
+function clearAll() {
+  _sessions.clear();
+}
+
+module.exports = { getSession, setSession, clearAll };

--- a/tests/artefact-writeback.test.js
+++ b/tests/artefact-writeback.test.js
@@ -27,6 +27,21 @@ async function test(name, fn) {
 }
 
 // ---------------------------------------------------------------------------
+// Test helpers for route handler tests
+// ---------------------------------------------------------------------------
+
+function makeReq(overrides) {
+  return Object.assign({ session: { accessToken: 'ghp_test', userId: 'user-1' }, params: {}, body: {} }, overrides);
+}
+
+function makeRes() {
+  const res = { statusCode: 200, headers: {}, body: null };
+  res.writeHead = function(code, hdrs) { res.statusCode = code; Object.assign(res.headers, hdrs || {}); };
+  res.end = function(data) { try { res.body = JSON.parse(data); } catch (_) { res.body = data; } };
+  return res;
+}
+
+// ---------------------------------------------------------------------------
 // T1 — commitArtefact SCM adapter (reuses/extends wuce.3 adapter)
 // Module under test: src/scm-adapter.js
 // ---------------------------------------------------------------------------
@@ -34,20 +49,68 @@ async function test(name, fn) {
 async function runT1() {
   process.stdout.write('\nT1 — commitArtefact SCM adapter\n');
 
+  const { commitArtefact: scmCommit, setAdapterForTest } = require('../src/scm-adapter');
+  const successFixture = JSON.parse(fs.readFileSync(path.join(__dirname, 'fixtures/github/contents-api-commit-success.json'), 'utf8'));
+
   await test('T1.1 — calls Contents API with correct path, content (base64), and user identity as committer', async () => {
-    assert.fail('not implemented');
+    const calls = [];
+    setAdapterForTest({ commitArtefact: async (opts) => { calls.push(opts); return successFixture; } });
+    await scmCommit({
+      path: 'artefacts/2026-05-02-ai-pipeline/discovery.md',
+      content: 'Hello world',
+      accessToken: 'ghp_test123',
+      userId: 'test-stakeholder',
+      sessionId: 'session-test-123',
+      skillName: 'discovery'
+    });
+    assert.strictEqual(calls.length, 1);
+    assert.strictEqual(calls[0].path, 'artefacts/2026-05-02-ai-pipeline/discovery.md');
+    assert.ok(calls[0].committer && calls[0].committer.name === 'test-stakeholder', 'committer identity set');
+    assert.strictEqual(calls[0].committer.email, 'test-stakeholder@users.noreply.github.com');
   });
 
   await test('T1.2 — commit message includes skill name and session ID', async () => {
-    assert.fail('not implemented');
+    const calls = [];
+    setAdapterForTest({ commitArtefact: async (opts) => { calls.push(opts); return successFixture; } });
+    await scmCommit({
+      path: 'artefacts/test-feature/benefit-metric.md',
+      content: 'metric content',
+      accessToken: 'ghp_test',
+      userId: 'user-1',
+      sessionId: 'sess-xyz-456',
+      skillName: 'benefit-metric'
+    });
+    assert.ok(calls[0].commitMessage.includes('benefit-metric'), 'commit message includes skill name');
+    assert.ok(calls[0].commitMessage.includes('sess-xyz-456'), 'commit message includes session ID');
   });
 
   await test('T1.3 — returns { sha, htmlUrl } on success', async () => {
-    assert.fail('not implemented');
+    setAdapterForTest({ commitArtefact: async () => successFixture });
+    const result = await scmCommit({
+      path: 'artefacts/test/file.md',
+      content: 'content',
+      accessToken: 'ghp_test',
+      userId: 'u1',
+      sessionId: 'sess-123',
+      skillName: 'discovery'
+    });
+    assert.strictEqual(result.sha, successFixture.commit.sha);
+    assert.strictEqual(result.htmlUrl, successFixture.content.html_url);
   });
 
   await test('T1.4 — propagates 409 conflict without swallowing it', async () => {
-    assert.fail('not implemented');
+    setAdapterForTest({ commitArtefact: async () => {
+      const err = new Error('409: Conflict'); err.status = 409; throw err;
+    }});
+    let caught = null;
+    try {
+      await scmCommit({
+        path: 'artefacts/test/file.md', content: 'c',
+        accessToken: 'ghp_test', userId: 'u1', sessionId: 's', skillName: 'discovery'
+      });
+    } catch (e) { caught = e; }
+    assert.ok(caught, 'error was thrown');
+    assert.strictEqual(caught.code, 'ARTEFACT_CONFLICT');
   });
 }
 
@@ -80,7 +143,18 @@ async function runT2() {
   });
 
   await test('T2.5 — client-supplied path in request body is ignored; server derives path from session context', async () => {
-    assert.fail('not implemented');
+    const { handlePostCommit, setSessionRegistryForTest } = require('../src/web-ui/routes/skill-commit');
+    const { setAdapterForTest } = require('../src/scm-adapter');
+    const fix = JSON.parse(fs.readFileSync(path.join(__dirname, 'fixtures/github/contents-api-commit-success.json'), 'utf8'));
+    const adapterCalls = [];
+    setAdapterForTest({ commitArtefact: async (opts) => { adapterCalls.push(opts); return fix; } });
+    const sessionData = { id: 'sess-t25', userId: 'user-t25', artefactPath: 'artefacts/2026-05-02-ai-pipeline/discovery.md', content: 'content text', state: 'complete' };
+    setSessionRegistryForTest({ getSession: (id) => id === 'sess-t25' ? sessionData : null });
+    const req = makeReq({ session: { accessToken: 'ghp_test', userId: 'user-t25' }, params: { name: 'discovery', id: 'sess-t25' }, body: { path: 'src/evil.js' } });
+    const res = makeRes();
+    await handlePostCommit(req, res);
+    assert.strictEqual(adapterCalls.length, 1, 'adapter called once');
+    assert.strictEqual(adapterCalls[0].path, 'artefacts/2026-05-02-ai-pipeline/discovery.md', 'session path used, not body path');
   });
 }
 
@@ -91,20 +165,45 @@ async function runT2() {
 async function runT3() {
   process.stdout.write('\nT3 — Commit route handler\n');
 
+  const { handlePostCommit, setSessionRegistryForTest, setCommitFnForTest } = require('../src/web-ui/routes/skill-commit');
+  const successFixture = JSON.parse(fs.readFileSync(path.join(__dirname, 'fixtures/github/contents-api-commit-success.json'), 'utf8'));
+
   await test('T3.1 — returns 201 with { sha, htmlUrl } on success', async () => {
-    assert.fail('not implemented');
+    const session = { id: 'sess-t31', userId: 'user-1', artefactPath: 'artefacts/2026-05-02-ai-pipeline/discovery.md', content: 'content', state: 'complete' };
+    setSessionRegistryForTest({ getSession: (id) => id === 'sess-t31' ? session : null });
+    setCommitFnForTest(async () => ({ sha: successFixture.commit.sha, htmlUrl: successFixture.content.html_url }));
+    const req = makeReq({ params: { name: 'discovery', id: 'sess-t31' } });
+    const res = makeRes();
+    await handlePostCommit(req, res);
+    assert.strictEqual(res.statusCode, 201);
+    assert.ok(res.body.sha, 'sha present');
+    assert.ok(res.body.htmlUrl, 'htmlUrl present');
   });
 
   await test('T3.2 — returns 401 when unauthenticated', async () => {
-    assert.fail('not implemented');
+    const req = makeReq({ session: null });
+    const res = makeRes();
+    await handlePostCommit(req, res);
+    assert.strictEqual(res.statusCode, 401);
   });
 
   await test('T3.3 — returns 403 when session belongs to a different user', async () => {
-    assert.fail('not implemented');
+    const session = { id: 'sess-t33', userId: 'user-2', artefactPath: 'artefacts/test/file.md', content: 'c', state: 'complete' };
+    setSessionRegistryForTest({ getSession: (id) => id === 'sess-t33' ? session : null });
+    const req = makeReq({ session: { accessToken: 'ghp_test', userId: 'user-1' }, params: { name: 'discovery', id: 'sess-t33' } });
+    const res = makeRes();
+    await handlePostCommit(req, res);
+    assert.strictEqual(res.statusCode, 403);
   });
 
   await test('T3.4 — returns 400 SESSION_NOT_COMPLETE when session not yet complete', async () => {
-    assert.fail('not implemented');
+    const session = { id: 'sess-t34', userId: 'user-1', artefactPath: 'artefacts/test/file.md', content: 'c', state: 'in-progress' };
+    setSessionRegistryForTest({ getSession: (id) => id === 'sess-t34' ? session : null });
+    const req = makeReq({ params: { name: 'discovery', id: 'sess-t34' } });
+    const res = makeRes();
+    await handlePostCommit(req, res);
+    assert.strictEqual(res.statusCode, 400);
+    assert.strictEqual(res.body.error, 'SESSION_NOT_COMPLETE');
   });
 }
 
@@ -115,12 +214,36 @@ async function runT3() {
 async function runT4() {
   process.stdout.write('\nT4 — Conflict handling\n');
 
+  const { handlePostCommit, setSessionRegistryForTest, setCommitFnForTest } = require('../src/web-ui/routes/skill-commit');
+  const EXISTING_URL = 'https://github.com/test-org/test-repo/blob/master/artefacts/test/file.md';
+
   await test('T4.1 — 409 response → message matches AC4 exact text', async () => {
-    assert.fail('not implemented');
+    const session = { id: 'sess-t41', userId: 'user-1', artefactPath: 'artefacts/test/file.md', content: 'c', state: 'complete' };
+    setSessionRegistryForTest({ getSession: (id) => id === 'sess-t41' ? session : null });
+    const conflictErr = new Error('Artefact already exists \u2014 reload and review before committing');
+    conflictErr.code = 'ARTEFACT_CONFLICT';
+    conflictErr.existingArtefactUrl = EXISTING_URL;
+    setCommitFnForTest(async () => { throw conflictErr; });
+    const req = makeReq({ params: { name: 'discovery', id: 'sess-t41' } });
+    const res = makeRes();
+    await handlePostCommit(req, res);
+    assert.strictEqual(res.statusCode, 409);
+    assert.strictEqual(res.body.message, 'Artefact already exists \u2014 reload and review before committing');
   });
 
   await test('T4.2 — 409 response includes existingArtefactUrl for the "view existing" option', async () => {
-    assert.fail('not implemented');
+    const session = { id: 'sess-t42', userId: 'user-1', artefactPath: 'artefacts/test/file.md', content: 'c', state: 'complete' };
+    setSessionRegistryForTest({ getSession: (id) => id === 'sess-t42' ? session : null });
+    const conflictErr = new Error('Artefact already exists \u2014 reload and review before committing');
+    conflictErr.code = 'ARTEFACT_CONFLICT';
+    conflictErr.existingArtefactUrl = EXISTING_URL;
+    setCommitFnForTest(async () => { throw conflictErr; });
+    const req = makeReq({ params: { name: 'discovery', id: 'sess-t42' } });
+    const res = makeRes();
+    await handlePostCommit(req, res);
+    assert.strictEqual(res.statusCode, 409);
+    assert.ok(res.body.existingArtefactUrl, 'existingArtefactUrl present');
+    assert.strictEqual(res.body.existingArtefactUrl, EXISTING_URL);
   });
 }
 
@@ -131,8 +254,19 @@ async function runT4() {
 async function runT5() {
   process.stdout.write('\nT5 — Confirmation response\n');
 
+  const { handlePostCommit, setSessionRegistryForTest, setCommitFnForTest } = require('../src/web-ui/routes/skill-commit');
+  const successFixture = JSON.parse(fs.readFileSync(path.join(__dirname, 'fixtures/github/contents-api-commit-success.json'), 'utf8'));
+
   await test('T5.1 — success response includes repo link (htmlUrl) and commit SHA (AC5)', async () => {
-    assert.fail('not implemented');
+    const session = { id: 'sess-t51', userId: 'user-1', artefactPath: 'artefacts/2026-05-02-ai-pipeline/discovery.md', content: 'content', state: 'complete' };
+    setSessionRegistryForTest({ getSession: (id) => id === 'sess-t51' ? session : null });
+    setCommitFnForTest(async () => ({ sha: successFixture.commit.sha, htmlUrl: successFixture.content.html_url }));
+    const req = makeReq({ params: { name: 'discovery', id: 'sess-t51' } });
+    const res = makeRes();
+    await handlePostCommit(req, res);
+    assert.strictEqual(res.statusCode, 201);
+    assert.strictEqual(res.body.sha, successFixture.commit.sha);
+    assert.strictEqual(res.body.htmlUrl, successFixture.content.html_url);
   });
 }
 
@@ -143,12 +277,32 @@ async function runT5() {
 async function runNFR() {
   process.stdout.write('\nNFR\n');
 
+  const { handlePostCommit, setSessionRegistryForTest, setCommitFnForTest } = require('../src/web-ui/routes/skill-commit');
+  const successFixture = JSON.parse(fs.readFileSync(path.join(__dirname, 'fixtures/github/contents-api-commit-success.json'), 'utf8'));
+
   await test('NFR1 — commit endpoint responds within 5s (including Contents API mock)', async () => {
-    assert.fail('not implemented');
+    const session = { id: 'sess-nfr1', userId: 'user-1', artefactPath: 'artefacts/test/file.md', content: 'c', state: 'complete' };
+    setSessionRegistryForTest({ getSession: (id) => id === 'sess-nfr1' ? session : null });
+    setCommitFnForTest(async () => ({ sha: successFixture.commit.sha, htmlUrl: successFixture.content.html_url }));
+    const req = makeReq({ params: { name: 'discovery', id: 'sess-nfr1' } });
+    const res = makeRes();
+    const start = Date.now();
+    await handlePostCommit(req, res);
+    const elapsed = Date.now() - start;
+    assert.ok(elapsed < 5000, 'responded in ' + elapsed + 'ms (limit: 5000ms)');
+    assert.strictEqual(res.statusCode, 201);
   });
 
   await test('NFR2 — OAuth token is never present in commit response or server logs', async () => {
-    assert.fail('not implemented');
+    const TOKEN = 'ghp_SECRETTOKEN123456789';
+    const session = { id: 'sess-nfr2', userId: 'user-1', artefactPath: 'artefacts/test/file.md', content: 'c', state: 'complete' };
+    setSessionRegistryForTest({ getSession: (id) => id === 'sess-nfr2' ? session : null });
+    setCommitFnForTest(async () => ({ sha: successFixture.commit.sha, htmlUrl: successFixture.content.html_url }));
+    const req = makeReq({ session: { accessToken: TOKEN, userId: 'user-1' }, params: { name: 'discovery', id: 'sess-nfr2' } });
+    const res = makeRes();
+    await handlePostCommit(req, res);
+    const responseStr = JSON.stringify(res.body);
+    assert.ok(!responseStr.includes(TOKEN), 'OAuth token not in response body');
   });
 }
 
@@ -159,12 +313,37 @@ async function runNFR() {
 async function runINT() {
   process.stdout.write('\nINT — Integration\n');
 
+  const { handlePostCommit, setSessionRegistryForTest, setCommitFnForTest } = require('../src/web-ui/routes/skill-commit');
+  const { setAdapterForTest } = require('../src/scm-adapter');
+  const successFixture = JSON.parse(fs.readFileSync(path.join(__dirname, 'fixtures/github/contents-api-commit-success.json'), 'utf8'));
+
   await test('INT1 — complete skill session → commit endpoint → Contents API called with correct identity', async () => {
-    assert.fail('not implemented');
+    const adapterCalls = [];
+    setAdapterForTest({ commitArtefact: async (opts) => { adapterCalls.push(opts); return successFixture; } });
+    setCommitFnForTest(null); // use real scm-adapter, which delegates to the mock wuce.3 adapter above
+    const session = { id: 'sess-int1', userId: 'test-stakeholder', artefactPath: 'artefacts/2026-05-02-ai-pipeline/discovery.md', content: 'discovery content', state: 'complete' };
+    setSessionRegistryForTest({ getSession: (id) => id === 'sess-int1' ? session : null });
+    const req = makeReq({ session: { accessToken: 'ghp_int_test', userId: 'test-stakeholder' }, params: { name: 'discovery', id: 'sess-int1' } });
+    const res = makeRes();
+    await handlePostCommit(req, res);
+    assert.strictEqual(res.statusCode, 201);
+    assert.ok(adapterCalls.length > 0, 'Contents API adapter was called');
+    assert.strictEqual(adapterCalls[0].path, 'artefacts/2026-05-02-ai-pipeline/discovery.md');
+    assert.strictEqual(adapterCalls[0].committer.name, 'test-stakeholder');
   });
 
   await test('INT2 — path traversal in client body → 400 returned; Contents API never called', async () => {
-    assert.fail('not implemented');
+    const adapterCalls = [];
+    setAdapterForTest({ commitArtefact: async (opts) => { adapterCalls.push(opts); return successFixture; } });
+    setCommitFnForTest(null); // use real scm-adapter so path validation runs
+    // Session with a traversal artefactPath — simulates a tampered session
+    const session = { id: 'sess-int2', userId: 'user-1', artefactPath: '../etc/passwd', content: 'c', state: 'complete' };
+    setSessionRegistryForTest({ getSession: (id) => id === 'sess-int2' ? session : null });
+    const req = makeReq({ params: { name: 'discovery', id: 'sess-int2' }, body: { path: '../etc/passwd' } });
+    const res = makeRes();
+    await handlePostCommit(req, res);
+    assert.strictEqual(res.statusCode, 400);
+    assert.strictEqual(adapterCalls.length, 0, 'Contents API was NOT called');
   });
 }
 


### PR DESCRIPTION
wuce.15: artefact-path-validator, scm-adapter (wraps wuce.3 per ADR-012), commit route POST sessions/:id/commit. 20/20 tests pass. Note: commitArtefact added to artefact-adapter.js (wuce.3). Closes #278.