### PR TITLE
feat: cdg.2 H2-H9 DoR gate checks

### DIFF
--- a/src/enforcement/cli-outer-loop.js
+++ b/src/enforcement/cli-outer-loop.js
@@ -1,5 +1,5 @@
 // cli-outer-loop.js — skills validate: artefact structural validation
-// Phase 1: H1 check (story artefact exists). Returns { exitCode, stdout, stderr }.
+// Implements H1-H9 DoR gate checks. Returns { exitCode, stdout, stderr }.
 // Pure function — no process.exit(), no file writes, no network calls.
 
 'use strict';
@@ -9,9 +9,19 @@ const path = require('path');
 
 const SUPPORTED_GATES = ['definition-of-ready'];
 
-// Pattern to find story artefact references in markdown content.
-// Matches: artefacts/<feature-slug>/stories/<story-slug>.md
+// Exit code constants — first-failing category determines the exit code.
+const EXIT = {
+  OK: 0,
+  H1: 1, H2: 2, H3: 3, H4: 4, H5: 5, H6: 6, H7_THROUGH_H9: 7, SYSTEM: 8,
+};
+
+// H1: embedded scan — matches artefacts/<feature-slug>/stories/<story-slug>.md
 const STORY_REF_RE = /artefacts\/[^/\s\n]+\/stories\/([^/\s\n.]+)\.md/g;
+
+// H2-H9: header-metadata extraction from DoR content
+const STORY_REF_HEADER_RE    = /\*\*Story reference:\*\*\s+(\S+\.md)/;
+const TESTPLAN_REF_HEADER_RE = /\*\*Test plan reference:\*\*\s+(\S+\.md)/;
+const REVIEW_REF_HEADER_RE   = /\*\*Review artefact:\*\*\s+(\S+\.md)/;
 
 /**
  * Validate an artefact against a gate.
@@ -30,7 +40,7 @@ function validate(artefactPath, gateName, repoRoot) {
   const rootWithSep = repoRoot.endsWith(path.sep) ? repoRoot : repoRoot + path.sep;
   if (!resolved.startsWith(rootWithSep)) {
     return {
-      exitCode: 8,
+      exitCode: EXIT.SYSTEM,
       stdout: '',
       stderr: 'Error: artefact path resolves outside repository root. Path traversal prevented (OWASP A01).',
     };
@@ -39,19 +49,19 @@ function validate(artefactPath, gateName, repoRoot) {
   // ── Gate validation ─────────────────────────────────────────────────────────
   if (!SUPPORTED_GATES.includes(gateName)) {
     return {
-      exitCode: 8,
+      exitCode: EXIT.SYSTEM,
       stdout: '',
       stderr: `UNSUPPORTED_GATE: '${gateName}' is not a recognised gate. Supported gates: ${SUPPORTED_GATES.join(', ')}`,
     };
   }
 
-  // ── H1: story artefact exists ───────────────────────────────────────────────
+  // ── H1: story artefact exists (embedded scan) ───────────────────────────────
   let content;
   try {
     content = fs.readFileSync(resolved, 'utf8');
   } catch (err) {
     return {
-      exitCode: 1,
+      exitCode: EXIT.H1,
       stdout: '',
       stderr: `H1 FAIL: could not read artefact (file not found or unreadable)`,
     };
@@ -64,16 +74,352 @@ function validate(artefactPath, gateName, repoRoot) {
     const absStoryPath = path.join(repoRoot, relStoryPath);
     if (!fs.existsSync(absStoryPath)) {
       return {
-        exitCode: 1,
+        exitCode: EXIT.H1,
         stdout: '',
         stderr: `H1 FAIL: story artefact not found at ${relStoryPath} (slug: ${match[1]})`,
       };
     }
   }
 
+  // ── H2-H9: header-metadata checks ──────────────────────────────────────────
+  // If no header-format story reference exists, H2-H9 are not applicable.
+  const storyHeaderMatch = STORY_REF_HEADER_RE.exec(content);
+  if (!storyHeaderMatch) {
+    return {
+      exitCode: EXIT.OK,
+      stdout: `validate OK: ${gateName} — 0 violations found`,
+      stderr: '',
+    };
+  }
+
+  const relStory = storyHeaderMatch[1];
+  const absStory = path.resolve(repoRoot, relStory);
+  if (!absStory.startsWith(rootWithSep)) {
+    return {
+      exitCode: EXIT.SYSTEM,
+      stdout: '',
+      stderr: 'Error: story header path resolves outside repository root. Path traversal prevented (OWASP A01).',
+    };
+  }
+
+  let storyContent;
+  try {
+    storyContent = fs.readFileSync(absStory, 'utf8');
+  } catch (_) {
+    return {
+      exitCode: EXIT.H1,
+      stdout: '',
+      stderr: `H1 FAIL: story artefact not found at ${relStory}`,
+    };
+  }
+
+  // ── H2: AC count and Given/When/Then format ─────────────────────────────────
+  {
+    const acMarkers = [];
+    const markerRe = /\*\*AC(\d+):\*\*/g;
+    let m;
+    while ((m = markerRe.exec(storyContent)) !== null) {
+      acMarkers.push({ n: parseInt(m[1], 10), pos: m.index });
+    }
+
+    if (acMarkers.length < 3) {
+      return {
+        exitCode: EXIT.H2,
+        stdout: '',
+        stderr: `H2 FAIL: minimum 3 ACs required, found ${acMarkers.length}`,
+      };
+    }
+
+    for (let i = 0; i < acMarkers.length; i++) {
+      const start = acMarkers[i].pos;
+      const end   = i + 1 < acMarkers.length ? acMarkers[i + 1].pos : storyContent.length;
+      const block = storyContent.slice(start, end).toLowerCase();
+      const missing = [];
+      if (!block.includes('given')) missing.push('Given');
+      if (!block.includes('when'))  missing.push('When');
+      if (!block.includes('then'))  missing.push('Then');
+      if (missing.length > 0) {
+        return {
+          exitCode: EXIT.H2,
+          stdout: '',
+          stderr: `H2 FAIL: AC${acMarkers[i].n} does not follow Given/When/Then format (missing: ${missing.join(', ')})`,
+        };
+      }
+    }
+  }
+
+  // ── H3: test plan existence and AC coverage ─────────────────────────────────
+  let tpContent;
+  {
+    const tpHeaderMatch = TESTPLAN_REF_HEADER_RE.exec(content);
+    if (!tpHeaderMatch) {
+      return {
+        exitCode: EXIT.H3,
+        stdout: '',
+        stderr: 'H3 FAIL: no test plan reference found in DoR (**Test plan reference:** <path>)',
+      };
+    }
+
+    const relTp = tpHeaderMatch[1];
+    const absTp = path.resolve(repoRoot, relTp);
+    if (!absTp.startsWith(rootWithSep)) {
+      return {
+        exitCode: EXIT.SYSTEM,
+        stdout: '',
+        stderr: 'Error: test plan path resolves outside repository root. Path traversal prevented (OWASP A01).',
+      };
+    }
+    if (!fs.existsSync(absTp)) {
+      return {
+        exitCode: EXIT.H3,
+        stdout: '',
+        stderr: `H3 FAIL: test plan not found at ${relTp}`,
+      };
+    }
+
+    tpContent = fs.readFileSync(absTp, 'utf8');
+    const acMarkerRe = /\*\*AC(\d+):\*\*/g;
+    let m;
+    while ((m = acMarkerRe.exec(storyContent)) !== null) {
+      const acLabel = `AC${m[1]}`;
+      if (!tpContent.includes(acLabel)) {
+        return {
+          exitCode: EXIT.H3,
+          stdout: '',
+          stderr: `H3 FAIL: ${acLabel} not covered in test plan`,
+        };
+      }
+    }
+  }
+
+  // ── H4: Out-of-scope section ────────────────────────────────────────────────
+  {
+    const oosSectionRe = /^#{1,3}\s+out[\s-]of[\s-]?scope\s*$/im;
+    const oosMatch = oosSectionRe.exec(storyContent);
+    if (!oosMatch) {
+      return {
+        exitCode: EXIT.H4,
+        stdout: '',
+        stderr: 'H4 FAIL: story has no "Out of Scope" section',
+      };
+    }
+
+    const bodyStart = oosMatch.index + oosMatch[0].length;
+    const nextHeadingMatch = /^#{1,3}\s+/m.exec(storyContent.slice(bodyStart));
+    const oosBody    = nextHeadingMatch
+      ? storyContent.slice(bodyStart, bodyStart + nextHeadingMatch.index)
+      : storyContent.slice(bodyStart);
+    const oosTrimmed = oosBody.trim();
+
+    if (!oosTrimmed) {
+      return {
+        exitCode: EXIT.H4,
+        stdout: '',
+        stderr: 'H4 FAIL: Out of Scope section body is blank',
+      };
+    }
+
+    const oosLower = oosTrimmed.toLowerCase();
+    if (oosLower === 'n/a' || oosLower === 'none' || oosLower === 'na') {
+      return {
+        exitCode: EXIT.H4,
+        stdout: '',
+        stderr: 'H4 FAIL: Out of Scope section is only "N/A" or "None" — populate with explicit constraints',
+      };
+    }
+  }
+
+  // ── H5: Benefit linkage ─────────────────────────────────────────────────────
+  {
+    const blSectionRe = /^#{1,3}\s+benefit[\s-]?linkage\s*$/im;
+    const blMatch = blSectionRe.exec(storyContent);
+    if (!blMatch) {
+      return {
+        exitCode: EXIT.H5,
+        stdout: '',
+        stderr: 'H5 FAIL: story has no "Benefit Linkage" section',
+      };
+    }
+
+    const bodyStart = blMatch.index + blMatch[0].length;
+    const nextHeadingMatch = /^#{1,3}\s+/m.exec(storyContent.slice(bodyStart));
+    const blBody    = nextHeadingMatch
+      ? storyContent.slice(bodyStart, bodyStart + nextHeadingMatch.index)
+      : storyContent.slice(bodyStart);
+    const blTrimmed = blBody.trim();
+
+    if (!/M\d+|[Mm]etric/.test(blTrimmed)) {
+      return {
+        exitCode: EXIT.H5,
+        stdout: '',
+        stderr: 'H5 FAIL: Benefit Linkage section does not reference a named metric (M[0-9]+ or "Metric")',
+      };
+    }
+
+    const blLower = blTrimmed.toLowerCase();
+    const disqualifyingPhrases = ['technical dependency', 'unblocks', 'needed for'];
+    const found = disqualifyingPhrases.find(phrase => blLower.includes(phrase));
+    if (found) {
+      return {
+        exitCode: EXIT.H5,
+        stdout: '',
+        stderr: `H5 FAIL: Benefit Linkage section describes a technical dependency ("${found}")`,
+      };
+    }
+  }
+
+  // ── H6: Complexity rating ───────────────────────────────────────────────────
+  {
+    if (!/complexity/i.test(storyContent)) {
+      return {
+        exitCode: EXIT.H6,
+        stdout: '',
+        stderr: 'H6 FAIL: story has no Complexity Rating section or field',
+      };
+    }
+
+    if (!/(?:complexity|rating)[^\n]*?(?::\s*|is\s+)[1-3]\b/i.test(storyContent)) {
+      return {
+        exitCode: EXIT.H6,
+        stdout: '',
+        stderr: 'H6 FAIL: Complexity rating value must be 1, 2, or 3',
+      };
+    }
+
+    if (!/scope\s+stability/i.test(storyContent)) {
+      return {
+        exitCode: EXIT.H6,
+        stdout: '',
+        stderr: 'H6 FAIL: Scope stability field is missing',
+      };
+    }
+  }
+
+  // ── H7: Review findings ─────────────────────────────────────────────────────
+  let rvContent;
+  {
+    const rvHeaderMatch = REVIEW_REF_HEADER_RE.exec(content);
+    if (!rvHeaderMatch) {
+      return {
+        exitCode: EXIT.H7_THROUGH_H9,
+        stdout: '',
+        stderr: 'H7 FAIL: no review artefact reference found in DoR (**Review artefact:** <path>)',
+      };
+    }
+
+    const relRv = rvHeaderMatch[1];
+    const absRv = path.resolve(repoRoot, relRv);
+    if (!absRv.startsWith(rootWithSep)) {
+      return {
+        exitCode: EXIT.SYSTEM,
+        stdout: '',
+        stderr: 'Error: review artefact path resolves outside repository root. Path traversal prevented (OWASP A01).',
+      };
+    }
+    if (!fs.existsSync(absRv)) {
+      return {
+        exitCode: EXIT.H7_THROUGH_H9,
+        stdout: '',
+        stderr: `H7 FAIL: review artefact not found at ${relRv}`,
+      };
+    }
+
+    rvContent = fs.readFileSync(absRv, 'utf8');
+    if (/\|\s*HIGH\b/i.test(rvContent)) {
+      return {
+        exitCode: EXIT.H7_THROUGH_H9,
+        stdout: '',
+        stderr: 'H7 FAIL: review artefact contains unresolved HIGH findings',
+      };
+    }
+  }
+
+  // ── H8: Test plan completeness ──────────────────────────────────────────────
+  {
+    if (!/coverage/i.test(tpContent)) {
+      return {
+        exitCode: EXIT.H7_THROUGH_H9,
+        stdout: '',
+        stderr: 'H8 FAIL: test plan has no AC coverage section',
+      };
+    }
+
+    const acMarkerRe = /\*\*AC(\d+):\*\*/g;
+    let m;
+    while ((m = acMarkerRe.exec(storyContent)) !== null) {
+      const acLabel = `AC${m[1]}`;
+      if (!tpContent.includes(acLabel)) {
+        return {
+          exitCode: EXIT.H7_THROUGH_H9,
+          stdout: '',
+          stderr: `H8 FAIL: ${acLabel} not in test plan coverage section`,
+        };
+      }
+    }
+  }
+
+  // ── H8-ext: Schema dependency check ────────────────────────────────────────
+  {
+    const depSectionRe = /^#{1,3}\s+dependencies\s*$/im;
+    const depMatch = depSectionRe.exec(storyContent);
+    if (depMatch) {
+      const bodyStart  = depMatch.index + depMatch[0].length;
+      const nextHeading = /^#{1,3}\s+/m.exec(storyContent.slice(bodyStart));
+      const depBody    = nextHeading
+        ? storyContent.slice(bodyStart, bodyStart + nextHeading.index)
+        : storyContent.slice(bodyStart);
+      const depTrimmed = depBody.trim().toLowerCase();
+      const hasUpstreamDeps = depTrimmed && depTrimmed !== 'none' && depTrimmed !== 'n/a';
+
+      if (hasUpstreamDeps && !/schemadepends:/i.test(content)) {
+        return {
+          exitCode: EXIT.H7_THROUGH_H9,
+          stdout: '',
+          stderr: 'H8-ext FAIL: story has upstream dependencies but DoR has no schemaDepends: declaration',
+        };
+      }
+    }
+  }
+
+  // ── H9: Architecture constraints ────────────────────────────────────────────
+  {
+    const archRe = /^#{1,3}\s+architecture\s+constraints/im;
+    const archMatch = archRe.exec(storyContent);
+    if (!archMatch) {
+      return {
+        exitCode: EXIT.H7_THROUGH_H9,
+        stdout: '',
+        stderr: 'H9 FAIL: story has no Architecture Constraints section',
+      };
+    }
+
+    const bodyStart  = archMatch.index + archMatch[0].length;
+    const nextHeading = /^#{1,3}\s+/m.exec(storyContent.slice(bodyStart));
+    const archBody   = nextHeading
+      ? storyContent.slice(bodyStart, bodyStart + nextHeading.index)
+      : storyContent.slice(bodyStart);
+    const archTrimmed = archBody.trim();
+
+    if (!archTrimmed) {
+      return {
+        exitCode: EXIT.H7_THROUGH_H9,
+        stdout: '',
+        stderr: 'H9 FAIL: Architecture Constraints section is blank',
+      };
+    }
+
+    if (!/ADR-\d+|guardrail|constraint/i.test(archTrimmed)) {
+      return {
+        exitCode: EXIT.H7_THROUGH_H9,
+        stdout: '',
+        stderr: 'H9 FAIL: Architecture Constraints section does not reference an ADR, guardrail, or named constraint',
+      };
+    }
+  }
+
   // ── All checks passed ───────────────────────────────────────────────────────
   return {
-    exitCode: 0,
+    exitCode: EXIT.OK,
     stdout: `validate OK: ${gateName} — 0 violations found`,
     stderr: '',
   };

--- a/tests/check-cli-governance.js
+++ b/tests/check-cli-governance.js
@@ -41,5 +41,30 @@ assert(fs.existsSync(MODULE), 'G1b: AC5 FAIL: src/enforcement/cli-outer-loop.js 
   assert(validateExported, "G1c: AC5 FAIL: src/enforcement/cli-outer-loop.js does not export a function named 'validate'");
 }
 
+console.log('\n[cli-governance] AC8 — fixture count and error map checks');
+
+// G2a — check-cli-outer-loop.js has at least 33 assert() calls
+{
+  let assertCount = 0;
+  try {
+    const src = fs.readFileSync(path.join(ROOT, 'tests', 'check-cli-outer-loop.js'), 'utf8');
+    const matches = src.match(/\bassert\(/g);
+    assertCount = matches ? matches.length : 0;
+  } catch (_) {}
+  assert(assertCount >= 33, `G2a: AC8 FAIL: check-cli-outer-loop.js has ${assertCount} assert() calls (need ≥33)`);
+}
+
+// G2b — cli-outer-loop.js defines EXIT constants (error code map)
+{
+  let hasExitMap = false;
+  if (fs.existsSync(MODULE)) {
+    try {
+      const src = fs.readFileSync(MODULE, 'utf8');
+      hasExitMap = /const\s+EXIT\s*=\s*\{/.test(src);
+    } catch (_) {}
+  }
+  assert(hasExitMap, 'G2b: AC8 FAIL: cli-outer-loop.js does not define EXIT constants map');
+}
+
 console.log(`\n=== check-cli-governance results: ${passed} passed, ${failed} failed ===\n`);
 if (failed > 0) process.exit(1);

--- a/tests/check-cli-outer-loop.js
+++ b/tests/check-cli-outer-loop.js
@@ -182,6 +182,247 @@ console.log('\n[cli-outer-loop] NFR3 — No new deps: package.json deps unchange
   assert(extraDevDeps.length === 0, `NFR3b: no extra entries in devDependencies (found: ${extraDevDeps.join(', ') || 'none'})`);
 }
 
+// ── T8 — H2: story with fewer than 3 ACs exits 2 ────────────────────────────
+console.log('\n[cli-outer-loop] T8 — H2: story with < 3 ACs → exit 2');
+{
+  const t8Dir = fs.mkdtempSync(path.join(ROOT, '.tmp-test-cdg2-t8-'));
+  try {
+    const storyPath = path.join(t8Dir, 'story-h2-few-acs.md');
+    fs.writeFileSync(storyPath, [
+      '## User Story',
+      'As a tester, I want to verify H2, So that the gate catches under-specified stories.',
+      '',
+      '## Acceptance Criteria',
+      '**AC1:** Given a baseline, When the check runs, Then it passes.',
+      'Given the baseline. When the check runs. Then it passes.',
+      '',
+      '**AC2:** Given another baseline, When the check runs, Then it also passes.',
+      'Given another baseline. When the check runs. Then it also passes.',
+      '',
+      '## Out of Scope',
+      'N/A',
+      '',
+      '## Benefit Linkage',
+      'M1 — test metric.',
+      '',
+      '## Complexity Rating',
+      'Rating: 2',
+      'Scope stability: Stable',
+      '',
+      '## Architecture Constraints',
+      'ADR-011 — pure function constraint.',
+    ].join('\n'), 'utf8');
+
+    const dorPath = path.join(t8Dir, 'dor.md');
+    fs.writeFileSync(dorPath, [
+      '## Definition of Ready',
+      '',
+      `**Story reference:** ${path.relative(ROOT, storyPath).replace(/\\/g, '/')}`,
+      `**Test plan reference:** ${path.relative(ROOT, storyPath).replace(/\\/g, '/')}`,
+      `**Review artefact:** ${path.relative(ROOT, storyPath).replace(/\\/g, '/')}`,
+    ].join('\n'), 'utf8');
+
+    const mod = loadModule();
+    let result = null;
+    if (mod) {
+      try { result = mod.validate(dorPath, 'definition-of-ready', ROOT); } catch (_) {}
+    }
+    assert(result !== null && result.exitCode === 2, 'T8a: exitCode === 2 for story with < 3 ACs');
+    assert(result !== null && typeof result.stderr === 'string' && result.stderr.includes('H2 FAIL'), 'T8b: stderr contains "H2 FAIL"');
+    assert(result !== null && typeof result.stderr === 'string' && result.stderr.includes('minimum 3 ACs required'), 'T8c: stderr contains "minimum 3 ACs required"');
+  } finally {
+    try { fs.rmSync(t8Dir, { recursive: true, force: true }); } catch (_) {}
+  }
+}
+
+// ── T9 — H2: story with 3 ACs but one missing GWT → exit 2 ──────────────────
+console.log('\n[cli-outer-loop] T9 — H2: story with AC missing Given/When/Then → exit 2');
+{
+  const t9Dir = fs.mkdtempSync(path.join(ROOT, '.tmp-test-cdg2-t9-'));
+  try {
+    const storyPath = path.join(t9Dir, 'story-h2-bad-gwt.md');
+    fs.writeFileSync(storyPath, [
+      '## User Story',
+      'As a tester, I want to verify H2 GWT, So that the gate catches malformed ACs.',
+      '',
+      '## Acceptance Criteria',
+      '**AC1:** Given a baseline, When the check runs, Then it passes.',
+      'Given a baseline. When the check runs. Then it passes.',
+      '',
+      '**AC2:** The system should work correctly.',
+      '',
+      '**AC3:** Given a third case, When tested, Then it works.',
+      'Given a third case. When tested. Then it works.',
+      '',
+      '## Out of Scope',
+      'N/A',
+      '',
+      '## Benefit Linkage',
+      'M1 — test metric.',
+      '',
+      '## Complexity Rating',
+      'Rating: 2',
+      'Scope stability: Stable',
+      '',
+      '## Architecture Constraints',
+      'ADR-011 — pure function constraint.',
+    ].join('\n'), 'utf8');
+
+    const dorPath = path.join(t9Dir, 'dor.md');
+    fs.writeFileSync(dorPath, [
+      '## Definition of Ready',
+      '',
+      `**Story reference:** ${path.relative(ROOT, storyPath).replace(/\\/g, '/')}`,
+      `**Test plan reference:** ${path.relative(ROOT, storyPath).replace(/\\/g, '/')}`,
+      `**Review artefact:** ${path.relative(ROOT, storyPath).replace(/\\/g, '/')}`,
+    ].join('\n'), 'utf8');
+
+    const mod = loadModule();
+    let result = null;
+    if (mod) {
+      try { result = mod.validate(dorPath, 'definition-of-ready', ROOT); } catch (_) {}
+    }
+    assert(result !== null && result.exitCode === 2, 'T9a: exitCode === 2 for story with AC2 missing GWT');
+    assert(result !== null && typeof result.stderr === 'string' && result.stderr.includes('H2 FAIL'), 'T9b: stderr contains "H2 FAIL"');
+    assert(result !== null && typeof result.stderr === 'string' && result.stderr.includes('AC2'), 'T9c: stderr identifies AC2 as the malformed AC');
+  } finally {
+    try { fs.rmSync(t9Dir, { recursive: true, force: true }); } catch (_) {}
+  }
+}
+
+// ── T10 — H5: story with disqualifying phrase in benefit linkage → exit 5 ────
+console.log('\n[cli-outer-loop] T10 — H5: disqualifying phrase in benefit linkage → exit 5');
+{
+  const t10Dir = fs.mkdtempSync(path.join(ROOT, '.tmp-test-cdg2-t10-'));
+  try {
+    const storyPath = path.join(t10Dir, 'story-h5-disqualify.md');
+    fs.writeFileSync(storyPath, [
+      '## User Story',
+      'As a tester, I want to verify H5, So that disqualifying phrases are caught.',
+      '',
+      '## Acceptance Criteria',
+      '**AC1:** Given a baseline, When the check runs, Then it passes.',
+      'Given a baseline. When the check runs. Then it passes.',
+      '',
+      '**AC2:** Given another case, When tested, Then it works.',
+      'Given another case. When tested. Then it works.',
+      '',
+      '**AC3:** Given a third case, When validated, Then it succeeds.',
+      'Given a third case. When validated. Then it succeeds.',
+      '',
+      '## Out of Scope',
+      'This is explicitly out of scope: widget integration.',
+      '',
+      '## Benefit Linkage',
+      'M1 — test metric. This story is needed for the next feature to proceed.',
+      '',
+      '## Complexity Rating',
+      'Rating: 2',
+      'Scope stability: Stable',
+      '',
+      '## Architecture Constraints',
+      'ADR-011 — pure function constraint.',
+    ].join('\n'), 'utf8');
+
+    const dorPath = path.join(t10Dir, 'dor.md');
+    fs.writeFileSync(dorPath, [
+      '## Definition of Ready',
+      '',
+      `**Story reference:** ${path.relative(ROOT, storyPath).replace(/\\/g, '/')}`,
+      `**Test plan reference:** ${path.relative(ROOT, storyPath).replace(/\\/g, '/')}`,
+      `**Review artefact:** ${path.relative(ROOT, storyPath).replace(/\\/g, '/')}`,
+    ].join('\n'), 'utf8');
+
+    const mod = loadModule();
+    let result = null;
+    if (mod) {
+      try { result = mod.validate(dorPath, 'definition-of-ready', ROOT); } catch (_) {}
+    }
+    assert(result !== null && result.exitCode === 5, 'T10a: exitCode === 5 for disqualifying phrase in benefit linkage');
+    assert(result !== null && typeof result.stderr === 'string' && result.stderr.includes('H5 FAIL'), 'T10b: stderr contains "H5 FAIL"');
+    assert(result !== null && typeof result.stderr === 'string' && result.stderr.includes('technical dependency'), 'T10c: stderr describes the disqualifying phrase type');
+  } finally {
+    try { fs.rmSync(t10Dir, { recursive: true, force: true }); } catch (_) {}
+  }
+}
+
+// ── T11 — clean DoR with all H-checks passing → exit 0 ──────────────────────
+console.log('\n[cli-outer-loop] T11 — clean DoR: all H-checks pass → exit 0');
+{
+  const t11Dir = fs.mkdtempSync(path.join(ROOT, '.tmp-test-cdg2-t11-'));
+  try {
+    const storyPath = path.join(t11Dir, 'story-clean.md');
+    fs.writeFileSync(storyPath, [
+      '## User Story',
+      'As a platform maintainer, I want the gate to pass clean stories, So that valid work proceeds.',
+      '',
+      '## Acceptance Criteria',
+      '**AC1:** Given a well-formed story, When the check runs, Then exit 0 is returned.',
+      'Given a well-formed story. When the check runs. Then exit 0 is returned.',
+      '',
+      '**AC2:** Given another AC, When validated, Then it also passes.',
+      'Given another AC. When validated. Then it also passes.',
+      '',
+      '**AC3:** Given a third AC, When the suite runs, Then all checks pass.',
+      'Given a third AC. When the suite runs. Then all checks pass.',
+      '',
+      '## Out of Scope',
+      'Widget integration and third-party API wiring are out of scope.',
+      '',
+      '## Benefit Linkage',
+      'M99 — dummy metric for test fixture validation.',
+      'This story implements the validation logic directly.',
+      '',
+      '## Complexity Rating',
+      'Rating: 2',
+      'Scope stability: Stable',
+      '',
+      '## Architecture Constraints',
+      'ADR-011 — pure function constraint applies. No state writes permitted.',
+    ].join('\n'), 'utf8');
+
+    const testPlanPath = path.join(t11Dir, 'test-plan-stub.md');
+    fs.writeFileSync(testPlanPath, [
+      '## Test Plan Stub',
+      '',
+      '## AC Coverage',
+      '',
+      '| AC | Tests |',
+      '|----|-------|',
+      '| AC1 | T1a |',
+      '| AC2 | T2a |',
+      '| AC3 | T3a |',
+    ].join('\n'), 'utf8');
+
+    const reviewPath = path.join(t11Dir, 'review-stub.md');
+    fs.writeFileSync(reviewPath, [
+      '## Review',
+      '',
+      '| Finding | Severity | Status |',
+      '|----|------|--------|',
+      '| No findings | LOW | resolved |',
+    ].join('\n'), 'utf8');
+
+    const dorPath = path.join(t11Dir, 'dor.md');
+    fs.writeFileSync(dorPath, [
+      '## Definition of Ready',
+      '',
+      `**Story reference:** ${path.relative(ROOT, storyPath).replace(/\\/g, '/')}`,
+      `**Test plan reference:** ${path.relative(ROOT, testPlanPath).replace(/\\/g, '/')}`,
+      `**Review artefact:** ${path.relative(ROOT, reviewPath).replace(/\\/g, '/')}`,
+    ].join('\n'), 'utf8');
+
+    const mod = loadModule();
+    let result = null;
+    if (mod) {
+      try { result = mod.validate(dorPath, 'definition-of-ready', ROOT); } catch (_) {}
+    }
+    assert(result !== null && result.exitCode === 0, 'T11a: exitCode === 0 for well-formed DoR');
+  } finally {
+    try { fs.rmSync(t11Dir, { recursive: true, force: true }); } catch (_) {}
+  }
+}
+
 // ── Cleanup ───────────────────────────────────────────────────────────────────
 try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch (_) {}
 


### PR DESCRIPTION
## Summary

Implements H2-H9 acceptance criteria checks in the `validate()` function.

**Changes:**
- `src/enforcement/cli-outer-loop.js`: H2 (AC count >=3 + GWT format), H3 (test plan existence + AC coverage), H4 (out-of-scope validity), H5 (benefit linkage metric + disqualifying phrases), H6 (complexity + scope stability), H7 (review exists, no HIGH findings), H8 (coverage section + AC in plan), H8-ext (schema deps), H9 (architecture constraints ADR ref)
- `tests/check-cli-outer-loop.js`: T8/T9/T10/T11 added — 33 assertions total
- `tests/check-cli-governance.js`: G2a (assert count >=33) + G2b (EXIT constants) added

**Exit codes:** H1=1, H2=2, H3=3, H4=4, H5=5, H6=6, H7-H9=7, SYSTEM=8

DoR artefact: `artefacts/2026-05-19-cli-deterministic-governance/dor/cdg.2-dor.md`
