### PR TITLE
feat(gpa-sc02): wire governance-package.evaluateGate for structural gate (ADR-013)

### DIFF
--- a/.github/pipeline-state.json
+++ b/.github/pipeline-state.json
@@ -3827,7 +3827,9 @@
           ]
         }
       ],
-      "stories": []
+      "stories": [],
+      "name": "Governance Platform Architecture",
+      "track": "standard"
     }
   ],
   "archive": ".github/pipeline-state-archive.json",

--- a/.github/pipeline-state.json
+++ b/.github/pipeline-state.json
@@ -3813,13 +3813,13 @@
               "slug": "gpa-sc-02-unified-gate-evaluator",
               "id": "gpa-sc-02-unified-gate-evaluator",
               "name": "Promote governance-package as single gate evaluator (ADR-013 compliance)",
-              "stage": "definition-of-ready",
+              "stage": "implementation",
               "health": "green",
               "reviewStatus": "passed",
               "reviewArtefact": "artefacts/2026-05-24-governance-platform-architecture/review/gpa-sc-02-unified-gate-evaluator-review-1.md",
               "reviewedAt": "2026-05-24",
               "dorStatus": "signed-off",
-              "prStatus": "none",
+              "prStatus": "draft",
               "testPlan": {
                 "status": "written"
               }

--- a/.github/scripts/run-assurance-gate.js
+++ b/.github/scripts/run-assurance-gate.js
@@ -25,6 +25,13 @@ const crypto = require('crypto');
 const DEFAULT_TRACES_DIR = path.join(__dirname, '..', '..', 'workspace', 'traces');
 const DEFAULT_ROOT       = path.join(__dirname, '..', '..');
 
+var _gp = null;
+try {
+  _gp = require('../../src/enforcement/governance-package');
+} catch (e) {
+  process.stderr.write('[run-assurance-gate] WARNING: governance-package not available, falling back to inline verdict derivation\n');
+}
+
 // ── Remediation hints map ────────────────────────────────────────────────────
 // Maps check names to human-readable hint + remediation action.
 // Populated in completedEntry on fail verdict only.
@@ -229,6 +236,7 @@ function runGate(ctx) {
     root         = DEFAULT_ROOT,
     checksRunner = null,
     runId        = buildRunId(trigger),
+    evaluateGateRunner = null,
     regulated         = false,
     standardsInjected = undefined,
     watermarkResult   = undefined,
@@ -281,8 +289,15 @@ function runGate(ctx) {
     );
   }
 
-  const allPassed = checks.every(function (c) { return c.passed; });
-  const verdict   = allPassed ? 'pass' : 'fail';
+  var _egFn = evaluateGateRunner || (_gp && _gp.evaluateGate) || null;
+  var verdict;
+  if (_egFn) {
+    var egResult = _egFn({ gate: 'structural', context: { checks: checks } });
+    verdict = egResult.passed ? 'pass' : 'fail';
+  } else {
+    var allPassed = checks.every(function (c) { return c.passed; });
+    verdict = allPassed ? 'pass' : 'fail';
+  }
   const failurePattern = verdict === 'fail' ? deriveFailurePattern(checks) : null;
 
   // Compute remediation hints for failing checks

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to this repository will be documented in this file.
 
 ### Added
 
+- **SC-02 (gpa-sc-02-unified-gate-evaluator):** `governance-package.evaluateGate` extended with a `structural` gate case; `run-assurance-gate.js` wired to call it for structural gate evaluation, fulfilling ADR-013 (shared gate authority). Falls back gracefully if governance-package is unavailable at module load.
+
 - **gpa-sc-06** — Path traversal guard added to `sourceIntegrity()` in `scripts/ci-audit-comment.js`; adversarial paths return `{ traversal: true, sanitisedPath: '[REDACTED]' }` without file read or raw path logging
 
 - **SC-03 gpa-sc-03-cli-validate-ci**: Wire `skills validate --story <slug> --ci` to CI assurance gate; `checkHGates(storySlug, repoRoot)` exported from `src/enforcement/governance-package.js` — checks dorStatus (skip if signed-off), scans for DoR artefact, runs H1-H9 gates via `cli-outer-loop.validate()`, returns canonical `[skills-validate] Results: N passed, N failed` output; `bin/skills` validate block extended with `--story --ci` dispatch path (no inline H-gate logic); `.github/workflows/assurance-gate.yml` gains a `continue-on-error: true` step that iterates flat and epic-nested stories and calls the CLI per story; 13 tests in `tests/check-gpa-sc03-cli-validate-ci.js`

--- a/src/enforcement/governance-package.js
+++ b/src/enforcement/governance-package.js
@@ -99,6 +99,14 @@ function evaluateGate({ gate, context }) {
       if (ctx.dodStatus !== 'complete') findings.push('dodStatus must be complete');
       break;
     }
+    case 'structural': {
+      const checks = (ctx.checks || []);
+      const failed = checks.filter(function (c) { return !c.passed; });
+      failed.forEach(function (c) {
+        findings.push(c.reason || ('Check failed: ' + c.name));
+      });
+      break;
+    }
     default: {
       findings.push(`Unknown gate: "${gate}"`);
     }

--- a/tests/check-gpa-sc02-unified-gate-evaluator.js
+++ b/tests/check-gpa-sc02-unified-gate-evaluator.js
@@ -1,0 +1,163 @@
+'use strict';
+const assert = require('assert');
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+
+const PREFIX = '[gpa-sc02]';
+let passed = 0; let failed = 0;
+function test(name, fn) {
+  try { fn(); console.log(PREFIX + ' PASS: ' + name); passed++; }
+  catch(e) { console.error(PREFIX + ' FAIL: ' + name + ' — ' + e.message); failed++; }
+}
+
+// T1 — structural gate all-pass
+test('T1 — evaluateGate structural all-pass returns {passed:true, findings:[]}', function() {
+  const { evaluateGate } = require('../src/enforcement/governance-package');
+  const result = evaluateGate({
+    gate: 'structural',
+    context: {
+      checks: [
+        { name: 'workspace-state-valid',   passed: true },
+        { name: 'pipeline-state-valid',    passed: true },
+        { name: 'artefacts-dir-exists',    passed: true },
+        { name: 'governance-gates-exists', passed: true },
+      ],
+    },
+  });
+  assert.strictEqual(result.passed, true);
+  assert.deepStrictEqual(result.findings, []);
+});
+
+// T2 — structural gate one-fail with reason
+test('T2 — evaluateGate structural one-fail returns reason in findings', function() {
+  const { evaluateGate } = require('../src/enforcement/governance-package');
+  const result = evaluateGate({
+    gate: 'structural',
+    context: {
+      checks: [
+        { name: 'workspace-state-valid',   passed: false, reason: 'workspace/state.json not found' },
+        { name: 'pipeline-state-valid',    passed: true },
+        { name: 'artefacts-dir-exists',    passed: true },
+        { name: 'governance-gates-exists', passed: true },
+      ],
+    },
+  });
+  assert.strictEqual(result.passed, false);
+  assert.deepStrictEqual(result.findings, ['workspace/state.json not found']);
+});
+
+// T3 — structural gate multiple failures
+test('T3 — evaluateGate structural multiple-fail collects all reasons', function() {
+  const { evaluateGate } = require('../src/enforcement/governance-package');
+  const result = evaluateGate({
+    gate: 'structural',
+    context: {
+      checks: [
+        { name: 'workspace-state-valid',   passed: false, reason: 'workspace/state.json not found' },
+        { name: 'pipeline-state-valid',    passed: true },
+        { name: 'artefacts-dir-exists',    passed: true },
+        { name: 'governance-gates-exists', passed: false, reason: '.github/governance-gates.yml not found' },
+      ],
+    },
+  });
+  assert.strictEqual(result.passed, false);
+  assert.deepStrictEqual(result.findings, ['workspace/state.json not found', '.github/governance-gates.yml not found']);
+});
+
+// T4 — source references governance-package
+test('T4 — run-assurance-gate.js references governance-package', function() {
+  const src = fs.readFileSync(path.join(__dirname, '../.github/scripts/run-assurance-gate.js'), 'utf8');
+  assert.ok(src.includes('governance-package'), 'source must reference governance-package');
+});
+
+// T5 — source calls evaluateGate with structural gate
+test('T5 — run-assurance-gate.js calls evaluateGate with structural gate', function() {
+  const src = fs.readFileSync(path.join(__dirname, '../.github/scripts/run-assurance-gate.js'), 'utf8');
+  assert.ok(src.includes('evaluateGate'), 'source must call evaluateGate');
+  assert.ok(src.includes("'structural'") || src.includes('"structural"'), "source must reference 'structural' gate");
+});
+
+// T6 — try/catch around governance-package require (NFR)
+test('T6 — run-assurance-gate.js has try/catch wrapping governance-package require', function() {
+  const src = fs.readFileSync(path.join(__dirname, '../.github/scripts/run-assurance-gate.js'), 'utf8');
+  // Both 'try' and 'governance-package' must appear, and try must come before governance-package in the require block
+  const tryIdx = src.indexOf('try');
+  const gpIdx  = src.indexOf('governance-package');
+  assert.ok(tryIdx !== -1, 'source must contain try block');
+  assert.ok(gpIdx  !== -1, 'source must reference governance-package');
+  // try block must appear before or very close to the governance-package require
+  assert.ok(tryIdx < gpIdx, 'try block must precede governance-package reference');
+});
+
+// IT1 — evaluateGateRunner hook is called when provided
+test('IT1 — evaluateGateRunner hook is called when provided in ctx', function() {
+  const { runGate } = require('../.github/scripts/run-assurance-gate');
+  const tmpDir  = fs.mkdtempSync(path.join(os.tmpdir(), 'sc02-it1-'));
+  const fakeRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'sc02-root1-'));
+  fs.mkdirSync(path.join(fakeRoot, 'workspace'));
+  fs.writeFileSync(path.join(fakeRoot, 'workspace', 'state.json'), '{}');
+  fs.mkdirSync(path.join(fakeRoot, '.github'), { recursive: true });
+  fs.writeFileSync(path.join(fakeRoot, '.github', 'pipeline-state.json'), '{}');
+  fs.mkdirSync(path.join(fakeRoot, 'artefacts'));
+  fs.writeFileSync(path.join(fakeRoot, '.github', 'governance-gates.yml'), 'gates: []');
+  let called = false;
+  function mockEGRunner(args) { called = true; return { passed: true, findings: [] }; }
+  runGate({ trigger: 'test', prRef: '', commitSha: 'abc', tracesDir: tmpDir, root: fakeRoot, evaluateGateRunner: mockEGRunner });
+  assert.ok(called, 'evaluateGateRunner must be called');
+});
+
+// IT2 — evaluateGateRunner receives correct arguments
+test('IT2 — evaluateGateRunner receives gate:structural and 4 check names', function() {
+  const { runGate } = require('../.github/scripts/run-assurance-gate');
+  const tmpDir   = fs.mkdtempSync(path.join(os.tmpdir(), 'sc02-it2-'));
+  const fakeRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'sc02-root2-'));
+  fs.mkdirSync(path.join(fakeRoot, 'workspace'));
+  fs.writeFileSync(path.join(fakeRoot, 'workspace', 'state.json'), '{}');
+  fs.mkdirSync(path.join(fakeRoot, '.github'), { recursive: true });
+  fs.writeFileSync(path.join(fakeRoot, '.github', 'pipeline-state.json'), '{}');
+  fs.mkdirSync(path.join(fakeRoot, 'artefacts'));
+  fs.writeFileSync(path.join(fakeRoot, '.github', 'governance-gates.yml'), 'gates: []');
+  let capturedArgs = null;
+  function mockEGRunner(args) { capturedArgs = args; return { passed: true, findings: [] }; }
+  runGate({ trigger: 'test', prRef: '', commitSha: 'abc', tracesDir: tmpDir, root: fakeRoot, evaluateGateRunner: mockEGRunner });
+  assert.ok(capturedArgs !== null, 'evaluateGateRunner must be called with args');
+  assert.strictEqual(capturedArgs.gate, 'structural', 'gate must be structural');
+  assert.ok(capturedArgs.context && Array.isArray(capturedArgs.context.checks), 'context.checks must be an array');
+  const checkNames = capturedArgs.context.checks.map(function(c) { return c.name; });
+  ['workspace-state-valid', 'pipeline-state-valid', 'artefacts-dir-exists', 'governance-gates-exists']
+    .forEach(function(n) { assert.ok(checkNames.includes(n), 'checks must include ' + n); });
+});
+
+// IT3 — verdict derived from evaluateGateRunner, not inline checks
+test('IT3 — verdict derived from evaluateGateRunner return, not inline checks.every', function() {
+  const { runGate } = require('../.github/scripts/run-assurance-gate');
+  const tmpDir   = fs.mkdtempSync(path.join(os.tmpdir(), 'sc02-it3-'));
+  const fakeRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'sc02-root3-'));
+  fs.mkdirSync(path.join(fakeRoot, 'workspace'));
+  fs.writeFileSync(path.join(fakeRoot, 'workspace', 'state.json'), '{}');
+  fs.mkdirSync(path.join(fakeRoot, '.github'), { recursive: true });
+  fs.writeFileSync(path.join(fakeRoot, '.github', 'pipeline-state.json'), '{}');
+  fs.mkdirSync(path.join(fakeRoot, 'artefacts'));
+  fs.writeFileSync(path.join(fakeRoot, '.github', 'governance-gates.yml'), 'gates: []');
+  // checksRunner: all checks fail; evaluateGateRunner: returns pass
+  // Before SC-02: verdict = 'fail' (inline checks.every)
+  // After SC-02:  verdict = 'pass' (from evaluateGateRunner)
+  function mockChecksRunner() {
+    return [
+      { name: 'workspace-state-valid',   passed: false, reason: 'injected-fail' },
+      { name: 'pipeline-state-valid',    passed: false, reason: 'injected-fail' },
+      { name: 'artefacts-dir-exists',    passed: false, reason: 'injected-fail' },
+      { name: 'governance-gates-exists', passed: false, reason: 'injected-fail' },
+    ];
+  }
+  function mockEGRunner() { return { passed: true, findings: [] }; }
+  const result = runGate({
+    trigger: 'test', prRef: '', commitSha: 'abc', tracesDir: tmpDir, root: fakeRoot,
+    checksRunner: mockChecksRunner, evaluateGateRunner: mockEGRunner,
+  });
+  assert.strictEqual(result.verdict, 'pass', 'verdict must come from evaluateGateRunner (pass), not inline checks (fail)');
+});
+
+console.log('\n' + PREFIX + ' Results: ' + passed + ' passed, ' + failed + ' failed');
+process.exit(failed > 0 ? 1 : 0);

--- a/tests/run-gpa-tests.js
+++ b/tests/run-gpa-tests.js
@@ -9,6 +9,7 @@ var GPA_TESTS = [
   'tests/check-gpa-sc01-trace-contract.js',
   'tests/check-gpa-sc05-skills-init.js',
   'tests/check-gpa-sc06-source-path-guard.js',
+  'tests/check-gpa-sc02-unified-gate-evaluator.js',
 ];
 
 var failed = false;


### PR DESCRIPTION
## Summary

Story: gpa-sc-02-unified-gate-evaluator

- `governance-package.evaluateGate` extended with `structural` gate case: accepts `context.checks[]` array, returns `{passed, findings}` with failed-check reason strings
- `run-assurance-gate.js` wired to call `evaluateGate({gate:'structural', context:{checks}})` instead of inline `checks.every` — fulfils ADR-013
- Graceful degradation: try/catch at module scope; falls back to inline logic if governance-package unavailable
- `evaluateGateRunner` ctx hook added for testability (mirrors existing `checksRunner` pattern)

## Test results

[gpa-sc02] Results: 9 passed, 0 failed

## Checklist
- [ ] Draft PR — do not merge